### PR TITLE
feat(assignments): retrieve user assignments from M‑Files, map required properties, and support completion

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/backend/src/Taskify.MFiles/bin/Debug/net8.0/Taskify.MFiles.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/backend/src/Taskify.MFiles",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/backend/Taskify.sln",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/backend/Taskify.sln",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/backend/Taskify.sln"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/backend/src/Taskify.Application/VaultConnection/Services/AssignmentService.cs
+++ b/backend/src/Taskify.Application/VaultConnection/Services/AssignmentService.cs
@@ -1,0 +1,75 @@
+using Taskify.Domain.Entities;
+using Taskify.Domain.Interfaces;
+
+namespace Taskify.Application.Assignments.Services;
+
+public class AssignmentService
+{
+    private readonly IAssignmentRepository _assignmentRepository;
+
+    public AssignmentService(IAssignmentRepository assignmentRepository)
+    {
+        _assignmentRepository = assignmentRepository;
+    }
+
+    public List<Assignment> GetUserAssignments()
+    {
+        try
+        {
+            var assignments = _assignmentRepository.GetUserAssignments();
+
+            // Sort by overdue first; within overdue, nearest due (most recent past) first.
+            // Then non-overdue by nearest future due date; null due dates last.
+            return assignments
+                .OrderByDescending(a => a.IsOverdue())
+                .ThenBy(a => a.IsOverdue()
+                    ? -(a.DueDate?.Ticks ?? long.MinValue) // overdue: more recent past first
+                    : (a.DueDate?.Ticks ?? long.MaxValue)) // non-overdue: earlier future first; nulls last
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error retrieving assignments: {ex.Message}");
+            throw;
+        }
+    }
+
+    public Assignment? GetAssignment(int assignmentId)
+    {
+        return _assignmentRepository.GetAssignmentById(assignmentId);
+    }
+
+    public bool CompleteAssignment(int assignmentId)
+    {
+        try
+        {
+            return _assignmentRepository.MarkAssignmentComplete(assignmentId);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error completing assignment {assignmentId}: {ex.Message}");
+            return false;
+        }
+    }
+
+    public AssignmentSummary GetAssignmentSummary()
+    {
+        var assignments = GetUserAssignments();
+
+        return new AssignmentSummary
+        {
+            TotalAssignments = assignments.Count,
+            CompletedAssignments = assignments.Count(a => a.Status == AssignmentStatus.Completed),
+            OverdueAssignments = assignments.Count(a => a.IsOverdue()),
+            DueSoonAssignments = assignments.Count(a => a.IsDueSoon())
+        };
+    }
+}
+
+public class AssignmentSummary
+{
+    public int TotalAssignments { get; set; }
+    public int CompletedAssignments { get; set; }
+    public int OverdueAssignments { get; set; }
+    public int DueSoonAssignments { get; set; }
+}

--- a/backend/src/Taskify.Domain/Entities/Assignment.cs
+++ b/backend/src/Taskify.Domain/Entities/Assignment.cs
@@ -1,0 +1,75 @@
+namespace Taskify.Domain.Entities;
+
+public class Assignment
+{
+    public int Id { get; set; }
+    public string Title { get; set; }
+    public string Description { get; set; }
+    public DateTime? DueDate { get; set; }
+    public AssignmentStatus Status { get; set; }
+    public string AssignedTo { get; set; }
+    public DateTime? CreatedDate { get; set; }
+    public DateTime? CompletedDate { get; set; }
+
+    public Assignment(int id, string title, string description, DateTime? dueDate, AssignmentStatus status, string assignedTo, DateTime? createdDate, DateTime? completedDate)
+    {
+        if (id <= 0)
+            throw new ArgumentException("Assignment ID must be greater than 0", nameof(id));
+
+        if (string.IsNullOrWhiteSpace(title))
+            throw new ArgumentException("Assignment title cannot be empty", nameof(title));
+
+        if (string.IsNullOrWhiteSpace(assignedTo))
+            throw new ArgumentException("Assignment assigned to cannot be empty", nameof(assignedTo));
+
+        if (completedDate.HasValue && completedDate.Value > DateTime.UtcNow)
+            throw new ArgumentException("Assignment completed date cannot be in the future", nameof(completedDate));
+
+        Id = id;
+        Title = title;
+        Description = description;
+        DueDate = dueDate;
+        Status = status;
+        AssignedTo = assignedTo;
+        CreatedDate = createdDate;
+        CompletedDate = completedDate;
+    }
+
+    public void MarkAsCompleted()
+    {
+        if (Status == AssignmentStatus.Completed)
+            throw new InvalidOperationException("Assignment is already completed");
+
+        Status = AssignmentStatus.Completed;
+        CompletedDate = DateTime.UtcNow;
+    }
+
+    public bool IsOverdue()
+    {
+        if (Status == AssignmentStatus.Completed || !DueDate.HasValue)
+            return false;
+
+        // Only dates before today are overdue; "due today" is not overdue
+        return DueDate.Value.Date < DateTime.UtcNow.Date;
+    }
+
+    public bool IsDueSoon(int daysThreshold = 3)
+    {
+        if (!DueDate.HasValue || Status == AssignmentStatus.Completed)
+            return false;
+
+        var daysUntilDue = (DueDate.Value - DateTime.UtcNow).TotalDays;
+        return daysUntilDue > 0 && daysUntilDue <= daysThreshold;
+    }
+
+}
+public enum AssignmentStatus
+{
+    NotStarted = 0,
+    InProgress = 1,
+    Completed = 2,
+    OnHold = 3,
+    WaitingForInformation = 4,
+    WaitingForFeedback = 5,
+    WaitingForReview = 6
+}

--- a/backend/src/Taskify.Domain/Entities/User.cs
+++ b/backend/src/Taskify.Domain/Entities/User.cs
@@ -1,0 +1,16 @@
+namespace Taskify.Domain.Entities;
+
+public class User
+{
+    public int Id { get; set; }
+    public string Username { get; set; }
+
+    public string FullName { get; set; }
+
+    public User(int id, string username, string fullName)
+    {
+        Id = id;
+        Username = username;
+        FullName = fullName;
+    }
+}

--- a/backend/src/Taskify.Domain/Interfaces/IAssignmentRepository.cs
+++ b/backend/src/Taskify.Domain/Interfaces/IAssignmentRepository.cs
@@ -1,0 +1,21 @@
+using Taskify.Domain.Entities;
+
+namespace Taskify.Domain.Interfaces;
+
+public interface IAssignmentRepository
+{
+    /// <summary>
+    /// Get all assignments for the current M-Files user
+    /// </summary>
+    List<Assignment> GetUserAssignments();
+
+    /// <summary>
+    /// Get an assignment by its ID
+    /// </summary>
+    Assignment? GetAssignmentById(int assignmentId);
+
+    /// <summary>
+    /// Mark an assignment as complete in M-Files
+    /// </summary>
+    bool MarkAssignmentComplete(int assignmentId);
+}

--- a/backend/src/Taskify.Domain/Interfaces/IVaultConnectionManager.cs
+++ b/backend/src/Taskify.Domain/Interfaces/IVaultConnectionManager.cs
@@ -11,5 +11,12 @@ public interface IVaultConnectionManager
     /// <summary>
     /// Gets the current vault connection details.
     /// </summary>
-    Vault GetVault();
+    Vault GetVaultInfo();
+
+    /// <summary>
+    /// Gets the raw M-Files vault connection for performing operations.
+    /// Returns object type to avoid domain layer dependency on MFilesAPI.
+    /// Cast to MFilesAPI.Vault in infrastructure layer.
+    /// </summary>
+    object GetVaultConnection();
 }

--- a/backend/src/Taskify.Infrastructure/MFilesInterop/MFilesAssignmentRepository.cs
+++ b/backend/src/Taskify.Infrastructure/MFilesInterop/MFilesAssignmentRepository.cs
@@ -113,29 +113,21 @@ public class MFilesAssignmentRepository : IAssignmentRepository
     {
         var vault = GetVault();
 
-        var objID = new ObjID();
-        objID.SetIDs(
+        var objVer = new ObjVer();
+        objVer.SetIDs(
             ObjType: (int)MFBuiltInObjectType.MFBuiltInObjectTypeAssignment,
-            ID: assignmentId);
-
-        // Check out the object
-        var objVersion = vault.ObjectOperations.CheckOut(objID);
-
-        // Update the assignment status property
-        vault.ObjectPropertyOperations.MarkAssignmentComplete(objVersion.ObjVer);
+            ID: assignmentId,
+            Version: -1
+        );
 
         try
         {
-            // Check in the object
-            vault.ObjectOperations.CheckIn(objVersion.ObjVer);
+            vault.ObjectPropertyOperations.MarkAssignmentComplete(objVer);
 
             return true;
         }
         catch (Exception ex)
         {
-            if (null != objVersion)
-                vault.ObjectOperations.UndoCheckout(objVersion.ObjVer);
-
             throw new ApplicationException("Failed to mark assignment as complete in M-Files", ex);
         }
     }

--- a/backend/src/Taskify.Infrastructure/MFilesInterop/MFilesAssignmentRepository.cs
+++ b/backend/src/Taskify.Infrastructure/MFilesInterop/MFilesAssignmentRepository.cs
@@ -1,0 +1,152 @@
+using MFilesAPI;
+using Taskify.Domain.Interfaces;
+using Taskify.Domain.Entities;
+using Taskify.Infrastructure.Mappers;
+
+namespace Taskify.Infrastructure.MFilesInterop;
+
+public class MFilesAssignmentRepository : IAssignmentRepository
+{
+    private readonly IVaultConnectionManager _connectionManager;
+
+    public MFilesAssignmentRepository(IVaultConnectionManager connectionManager)
+    {
+        _connectionManager = connectionManager;
+    }
+
+    public List<Assignment> GetUserAssignments()
+    {
+        try
+        {
+            var vault = GetVault();
+
+            // Create search conditions
+            var searchConditions = new SearchConditions();
+
+            // Condition 1: Not deleted
+            var deletedCondition = new SearchCondition
+            {
+                ConditionType = MFConditionType.MFConditionTypeEqual
+            };
+            deletedCondition.Expression.SetStatusValueExpression(MFStatusType.MFStatusTypeDeleted);
+            deletedCondition.TypedValue.SetValue(MFDataType.MFDatatypeBoolean, false);
+            searchConditions.Add(-1, deletedCondition);
+
+            // Condition 2: Object type = Assignment
+            var objectTypeCondition = new SearchCondition
+            {
+                ConditionType = MFConditionType.MFConditionTypeEqual
+            };
+            objectTypeCondition.Expression.SetStatusValueExpression(MFStatusType.MFStatusTypeObjectTypeID);
+            objectTypeCondition.TypedValue.SetValue(
+                MFDataType.MFDatatypeLookup,
+                (int)MFBuiltInObjectType.MFBuiltInObjectTypeAssignment);
+            searchConditions.Add(-1, objectTypeCondition);
+
+            // Condition 3: Assigned to current user
+            var assignedToCondition = new SearchCondition
+            {
+                ConditionType = MFConditionType.MFConditionTypeEqual
+            };
+            assignedToCondition.Expression.SetPropertyValueExpression(
+                (int)MFBuiltInPropertyDef.MFBuiltInPropertyDefAssignedTo,
+                MFParentChildBehavior.MFParentChildBehaviorNone);
+            assignedToCondition.TypedValue.SetValue(
+                MFDataType.MFDatatypeLookup,
+                vault.CurrentLoggedInUserID);
+            searchConditions.Add(-1, assignedToCondition);
+
+            // Execute search
+            var searchResults = vault.ObjectSearchOperations.SearchForObjectsByConditions(
+                searchConditions,
+                MFSearchFlags.MFSearchFlagNone,
+                SortResults: false);
+
+            var assignments = new List<Assignment>();
+
+            for (int i = 1; i <= searchResults.Count; i++)
+            {
+                try
+                {
+                    var objVersion = searchResults[i];
+                    var assignment = MFilesDataMapper.MapToDomainAssignment(vault, objVersion);
+                    assignments.Add(assignment);
+                }
+                catch (Exception ex)
+                {
+                    // Log but don't fail entire operation for one bad assignment
+                    Console.WriteLine($"Warning: Failed to map assignment {searchResults[i].ObjVer.ID}: {ex.Message}");
+                }
+            }
+
+            return assignments;
+
+        }
+        catch (Exception ex)
+        {
+            throw new ApplicationException("Failed to get user assignments from M-Files", ex);
+        }
+    }
+
+    public Assignment? GetAssignmentById(int assignmentId)
+    {
+        try
+        {
+            var vault = GetVault();
+
+            var objID = new ObjID();
+            objID.SetIDs(
+                ObjType: (int)MFBuiltInObjectType.MFBuiltInObjectTypeAssignment,
+                ID: assignmentId);
+
+            var objVersion = vault.ObjectOperations.GetLatestObjectVersionAndProperties(objID, AllowCheckedOut: true);
+
+            return MFilesDataMapper.MapToDomainAssignment(vault, objVersion.VersionData);
+        }
+        catch (Exception ex)
+        {
+            throw new ApplicationException("Failed to get assignment by ID from M-Files", ex);
+        }
+    }
+
+    public bool MarkAssignmentComplete(int assignmentId)
+    {
+        var vault = GetVault();
+
+        var objID = new ObjID();
+        objID.SetIDs(
+            ObjType: (int)MFBuiltInObjectType.MFBuiltInObjectTypeAssignment,
+            ID: assignmentId);
+
+        // Check out the object
+        var objVersion = vault.ObjectOperations.CheckOut(objID);
+
+        // Update the assignment status property
+        vault.ObjectPropertyOperations.MarkAssignmentComplete(objVersion.ObjVer);
+
+        try
+        {
+            // Check in the object
+            vault.ObjectOperations.CheckIn(objVersion.ObjVer);
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            if (null != objVersion)
+                vault.ObjectOperations.UndoCheckout(objVersion.ObjVer);
+
+            throw new ApplicationException("Failed to mark assignment as complete in M-Files", ex);
+        }
+    }
+
+    private MFilesAPI.Vault GetVault()
+    {
+        var vaultConnection = _connectionManager.GetVaultConnection();
+
+        if (vaultConnection is not MFilesAPI.Vault vault)
+            throw new InvalidOperationException("Failed to get M-Files vault connection");
+
+        return vault;
+    }
+}

--- a/backend/src/Taskify.Infrastructure/Mappers/MFilesDataMapper.cs
+++ b/backend/src/Taskify.Infrastructure/Mappers/MFilesDataMapper.cs
@@ -1,14 +1,92 @@
 namespace Taskify.Infrastructure.Mappers;
 
+using MFilesAPI;
 using Taskify.Domain.Entities;
+using System.Linq;
+using System.ComponentModel;
 
 public static class MFilesDataMapper
 {
-    public static Vault MapToDomainVault(MFilesAPI.Vault mfilesVault)
+    public static Domain.Entities.Vault MapToDomainVault(MFilesAPI.Vault mfilesVault)
     {
-        return new Vault(
+        return new Domain.Entities.Vault(
             name: mfilesVault.Name,
             guid: mfilesVault.GetGUID()
         );
+    }
+
+    public static Assignment MapToDomainAssignment(MFilesAPI.Vault vault, ObjectVersion objVersion)
+    {
+        var properties = vault.ObjectPropertyOperations.GetProperties(objVersion.ObjVer);
+
+        return new Assignment(
+            id: objVersion.ObjVer.ID,
+            title: GetPropertyValue<string>(properties, (int)MFBuiltInPropertyDef.MFBuiltInPropertyDefNameOrTitle) ?? "Untitled",
+            description: GetPropertyValue<string>(properties, (int)MFBuiltInPropertyDef.MFBuiltInPropertyDefAssignmentDescription) ?? string.Empty,
+            dueDate: GetPropertyValue<DateTime?>(properties, (int)MFBuiltInPropertyDef.MFBuiltInPropertyDefDeadline),
+            status: MapAssignmentStatus(properties),
+            assignedTo: GetAssignedToName(vault, properties),
+            createdDate: GetPropertyValue<DateTime>(properties, (int)MFBuiltInPropertyDef.MFBuiltInPropertyDefCreated),
+            completedDate: GetPropertyValue<DateTime?>(properties, (int)MFBuiltInPropertyDef.MFBuiltInPropertyDefCreated) // TODO: Write function to get date completed.
+        );
+    }
+
+    private static T? GetPropertyValue<T>(PropertyValues properties, int propertyDef)
+    {
+        try
+        {
+            var propValue = properties.SearchForProperty(propertyDef);
+            if (propValue == null || propValue.TypedValue.IsNULL() || propValue.TypedValue.IsUninitialized())
+                return default;
+
+            var value = propValue.TypedValue.Value;
+
+            if (typeof(T) == typeof(DateTime) || typeof(T) == typeof(DateTime?))
+            {
+                // M-Files returns date as object, need to convert
+                if (value is DateTime dt)
+                    return (T)(object)dt;
+                return default;
+            }
+
+            return (T)value;
+        }
+        catch
+        {
+            return default;
+        }
+    }
+
+    private static AssignmentStatus MapAssignmentStatus(PropertyValues properties)
+    {
+        // Check if assignment is complete
+        var completed = GetPropertyValue<bool>(properties, (int)MFBuiltInPropertyDef.MFBuiltInPropertyDefAssignedTo);
+        if (completed)
+            return AssignmentStatus.Completed;
+
+        // You may need to check workflow state or other properties depending on your M-Files setup
+        // For now, assume InProgress if not completed
+        return AssignmentStatus.InProgress;
+    }
+
+    private static string GetAssignedToName(MFilesAPI.Vault vault, PropertyValues properties)
+    {
+        try
+        {
+            var assignedToProp = properties.SearchForProperty((int)MFBuiltInPropertyDef.MFBuiltInPropertyDefAssignedTo);
+            if (assignedToProp == null || assignedToProp.TypedValue.IsNULL())
+                return "Unassigned";
+
+            var userName = assignedToProp.TypedValue.GetValueAsLookups()
+                .Cast<Lookup>()
+                .FirstOrDefault(a => int.Parse(a.DisplayID) == vault.CurrentLoggedInUserID)
+                ?.DisplayValue;
+
+            return userName ?? "Unknown";
+        }
+        catch
+        {
+            return "Unknown";
+        }
     }
 }

--- a/backend/tests/Taskify.Tests/Unit/Application/Assignments/AssignmentServiceTests.cs
+++ b/backend/tests/Taskify.Tests/Unit/Application/Assignments/AssignmentServiceTests.cs
@@ -1,0 +1,145 @@
+using Xunit;
+using Moq;
+using Taskify.Application.Assignments.Services;
+using Taskify.Domain.Entities;
+using Taskify.Domain.Interfaces;
+
+namespace Taskify.Tests.Unit.Application.Assignments;
+
+public class AssignmentServiceTests
+{
+    private static Assignment MakeAssignment(
+        int id,
+        string title,
+        DateTime? dueDate,
+        AssignmentStatus status = AssignmentStatus.InProgress,
+        string assignedTo = "user",
+        DateTime? created = null,
+        DateTime? completed = null)
+    {
+        return new Assignment(
+            id: id,
+            title: title,
+            description: "",
+            dueDate: dueDate,
+            status: status,
+            assignedTo: assignedTo,
+            createdDate: created ?? DateTime.UtcNow.AddDays(-1),
+            completedDate: completed
+        );
+    }
+
+    [Fact]
+    public void GetUserAssignments_Sorts_Overdue_First_Then_By_Nearest_DueDate()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+        var overdueFar = MakeAssignment(1, "overdue-10d", now.AddDays(-10));
+        var dueSoonTomorrow = MakeAssignment(2, "due+1d", now.AddDays(1));
+        var overdueNear = MakeAssignment(3, "overdue-1d", now.AddDays(-1));
+        var dueLater = MakeAssignment(4, "due+5d", now.AddDays(5));
+        var noDue = MakeAssignment(5, "no-due", null);
+
+        var list = new List<Assignment> { dueLater, overdueFar, noDue, dueSoonTomorrow, overdueNear };
+
+        var repo = new Mock<IAssignmentRepository>();
+        repo.Setup(r => r.GetUserAssignments()).Returns(list);
+
+        var svc = new AssignmentService(repo.Object);
+
+        // Act
+        var result = svc.GetUserAssignments();
+
+        // Assert
+        Assert.Equal(new[] { 3, 1, 2, 4, 5 }, result.Select(a => a.Id).ToArray());
+    }
+
+    [Fact]
+    public void GetUserAssignments_Propagates_Exception()
+    {
+        // Arrange
+        var repo = new Mock<IAssignmentRepository>();
+        repo.Setup(r => r.GetUserAssignments()).Throws(new ApplicationException("boom"));
+        var svc = new AssignmentService(repo.Object);
+
+        // Act + Assert
+        var ex = Assert.Throws<ApplicationException>(() => svc.GetUserAssignments());
+        Assert.Equal("boom", ex.Message);
+    }
+
+    [Fact]
+    public void GetAssignment_Forwards_To_Repository()
+    {
+        // Arrange
+        var expected = MakeAssignment(42, "x", DateTime.UtcNow.AddDays(2));
+        var repo = new Mock<IAssignmentRepository>();
+        repo.Setup(r => r.GetAssignmentById(42)).Returns(expected);
+        var svc = new AssignmentService(repo.Object);
+
+        // Act
+        var result = svc.GetAssignment(42);
+
+        // Assert
+        Assert.Same(expected, result);
+        repo.Verify(r => r.GetAssignmentById(42), Times.Once);
+    }
+
+    [Fact]
+    public void CompleteAssignment_Returns_True_When_Repository_Succeeds()
+    {
+        // Arrange
+        var repo = new Mock<IAssignmentRepository>();
+        repo.Setup(r => r.MarkAssignmentComplete(7)).Returns(true);
+        var svc = new AssignmentService(repo.Object);
+
+        // Act
+        var ok = svc.CompleteAssignment(7);
+
+        // Assert
+        Assert.True(ok);
+        repo.Verify(r => r.MarkAssignmentComplete(7), Times.Once);
+    }
+
+    [Fact]
+    public void CompleteAssignment_Returns_False_When_Repository_Throws()
+    {
+        // Arrange
+        var repo = new Mock<IAssignmentRepository>();
+        repo.Setup(r => r.MarkAssignmentComplete(7)).Throws(new InvalidOperationException("fail"));
+        var svc = new AssignmentService(repo.Object);
+
+        // Act
+        var ok = svc.CompleteAssignment(7);
+
+        // Assert
+        Assert.False(ok);
+        repo.Verify(r => r.MarkAssignmentComplete(7), Times.Once);
+    }
+
+    [Fact]
+    public void GetAssignmentSummary_Computes_Correct_Aggregates()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+
+        var a1 = MakeAssignment(1, "completed", now.AddDays(-5), AssignmentStatus.Completed, completed: now.AddDays(-4));
+        var a2 = MakeAssignment(2, "overdue", now.AddDays(-1), AssignmentStatus.InProgress);
+        var a3 = MakeAssignment(3, "due soon", now.AddDays(2), AssignmentStatus.InProgress);
+        var a4 = MakeAssignment(4, "not due soon", now.AddDays(10), AssignmentStatus.InProgress);
+        var a5 = MakeAssignment(5, "no due", null, AssignmentStatus.InProgress);
+
+        var repo = new Mock<IAssignmentRepository>();
+        repo.Setup(r => r.GetUserAssignments()).Returns(new List<Assignment> { a1, a2, a3, a4, a5 });
+
+        var svc = new AssignmentService(repo.Object);
+
+        // Act
+        var summary = svc.GetAssignmentSummary();
+
+        // Assert
+        Assert.Equal(5, summary.TotalAssignments);
+        Assert.Equal(1, summary.CompletedAssignments);    // a1
+        Assert.Equal(1, summary.OverdueAssignments);      // a2
+        Assert.Equal(1, summary.DueSoonAssignments);      // a3 (2 days)
+    }
+}

--- a/backend/tests/Taskify.Tests/Unit/Domain/AssignmentTests.cs
+++ b/backend/tests/Taskify.Tests/Unit/Domain/AssignmentTests.cs
@@ -1,0 +1,127 @@
+using Xunit;
+using Taskify.Domain.Entities;
+
+namespace Taskify.Tests.Unit.Domain;
+
+public class AssignmentTests
+{
+    [Fact]
+    public void Constructor_With_Valid_Parameters_Creates_Instance()
+    {
+        var due = DateTime.UtcNow.AddDays(3);
+        var created = DateTime.UtcNow.AddDays(-1);
+
+        var a = new Assignment(
+            id: 1,
+            title: "Title",
+            description: "Desc",
+            dueDate: due,
+            status: AssignmentStatus.InProgress,
+            assignedTo: "user",
+            createdDate: created,
+            completedDate: null
+        );
+
+        Assert.Equal(1, a.Id);
+        Assert.Equal("Title", a.Title);
+        Assert.Equal("user", a.AssignedTo);
+        Assert.Equal(AssignmentStatus.InProgress, a.Status);
+        Assert.Equal(due, a.DueDate);
+        Assert.Equal(created, a.CreatedDate);
+        Assert.Null(a.CompletedDate);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_Id_Must_Be_Positive(int id)
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            new Assignment(id, "Title", "", null, AssignmentStatus.InProgress, "user", DateTime.UtcNow, null));
+        Assert.Contains("Assignment ID must be greater than 0", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_Title_Required(string title)
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            new Assignment(1, title!, "", null, AssignmentStatus.InProgress, "user", DateTime.UtcNow, null));
+        Assert.Contains("Assignment title cannot be empty", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_AssignedTo_Required(string assignedTo)
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            new Assignment(1, "Title", "", null, AssignmentStatus.InProgress, assignedTo!, DateTime.UtcNow, null));
+        Assert.Contains("Assignment assigned to cannot be empty", ex.Message);
+    }
+
+    [Fact]
+    public void Constructor_CompletedDate_Cannot_Be_In_Future()
+    {
+        var future = DateTime.UtcNow.AddMinutes(1);
+        var ex = Assert.Throws<ArgumentException>(() =>
+            new Assignment(1, "Title", "", null, AssignmentStatus.InProgress, "user", DateTime.UtcNow, future));
+        Assert.Contains("completed date cannot be in the future", ex.Message);
+    }
+
+    [Fact]
+    public void MarkAsCompleted_Sets_Status_And_CompletedDate()
+    {
+        var a = new Assignment(1, "Title", "", null, AssignmentStatus.InProgress, "user", DateTime.UtcNow, null);
+
+        a.MarkAsCompleted();
+
+        Assert.Equal(AssignmentStatus.Completed, a.Status);
+        Assert.True(a.CompletedDate.HasValue);
+        Assert.True((DateTime.UtcNow - a.CompletedDate.Value).TotalSeconds < 5);
+    }
+
+    [Fact]
+    public void MarkAsCompleted_When_Already_Completed_Throws()
+    {
+        var a = new Assignment(1, "Title", "", null, AssignmentStatus.Completed, "user", DateTime.UtcNow, DateTime.UtcNow.AddMinutes(-1));
+        var ex = Assert.Throws<InvalidOperationException>(() => a.MarkAsCompleted());
+        Assert.Equal("Assignment is already completed", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(-1, true)]   // overdue
+    [InlineData(0, false)]   // due now is not overdue
+    [InlineData(1, false)]   // future
+    public void IsOverdue_Behavior(int daysOffset, bool expected)
+    {
+        var due = DateTime.UtcNow.AddDays(daysOffset);
+        var a = new Assignment(1, "Title", "", due, AssignmentStatus.InProgress, "user", DateTime.UtcNow, null);
+
+        Assert.Equal(expected, a.IsOverdue());
+    }
+
+    [Theory]
+    [InlineData(1, true)]   // within 3 days
+    [InlineData(3, true)]   // exactly threshold
+    [InlineData(4, false)]  // beyond threshold
+    public void IsDueSoon_Default_Threshold(int daysAhead, bool expected)
+    {
+        var due = DateTime.UtcNow.AddDays(daysAhead);
+        var a = new Assignment(1, "Title", "", due, AssignmentStatus.InProgress, "user", DateTime.UtcNow, null);
+
+        Assert.Equal(expected, a.IsDueSoon());
+    }
+
+    [Fact]
+    public void IsDueSoon_Ignores_Completed_Assignments()
+    {
+        var due = DateTime.UtcNow.AddDays(1);
+        var a = new Assignment(1, "Title", "", due, AssignmentStatus.Completed, "user", DateTime.UtcNow, DateTime.UtcNow);
+
+        Assert.False(a.IsDueSoon());
+    }
+}


### PR DESCRIPTION
# Description
- Implement end-to-end assignment retrieval for the current user via M‑Files:
    - Query user assignments from the vault.
    - Map required properties to domain Assignment (id, title, description, due date, status, assigned to, created/completed dates).

- Add application service operations:
    - GetUserAssignments() with business-aware ordering: overdue first (nearest past due first), then upcoming by nearest due date; null due last.
    - GetAssignment(int id) to fetch a specific assignment.
    - CompleteAssignment(int id) to mark as completed through the repository.

- Domain behavior:
    - Validation on construction.
    - MarkAsCompleted() sets status/date.
    - IsOverdue() uses date-only comparison so “due today” is not overdue.
    - IsDueSoon() helper for summaries.

- Wiring:
    - IAssignmentRepository contract.
    - MFilesAssignmentRepository + MFilesDataMapper + MFilesVaultConnectionManager integration.

- Tests:
    - Unit tests covering domain rules, sorting, completion, and summary all pass (43/43).

Closes #3 