### PR TITLE
feat(subtasks): add inline subtask title editing

### DIFF
--- a/backend/src/Taskify.Api/Program.cs
+++ b/backend/src/Taskify.Api/Program.cs
@@ -219,6 +219,22 @@ app.MapPost("api/subtasks/{id:int}/toggle", async (int id, SubtaskService svc, H
     var ok = svc.ToggleSubtaskCompletion(id, body.IsCompleted);
     return ok ? Results.Ok() : Results.BadRequest();
 });
+app.MapPut("api/subtasks/{id:int}/title", async (int id, SubtaskService svc, HttpRequest req) =>
+{
+    var body = await req.ReadFromJsonAsync<UpdateSubtaskTitleRequest>();
+    if (body == null)
+        return Results.BadRequest("body required");
+
+    try
+    {
+        var ok = svc.UpdateSubtaskTitle(id, body.Title);
+        return ok ? Results.Ok() : Results.NotFound();
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ex.Message);
+    }
+});
 app.MapPut("api/subtasks/{id:int}/note", async (int id, SubtaskService svc, HttpRequest req) =>
 {
     var body = await req.ReadFromJsonAsync<UpdateNoteRequest>();
@@ -263,6 +279,7 @@ app.Run();
 public record AddCommentRequest(string Content);
 public record AddSubtaskRequest(string Title, int? Order);
 public record ToggleSubtaskRequest(bool IsCompleted);
+public record UpdateSubtaskTitleRequest(string Title);
 public record UpdateNoteRequest(string? Note);
 public record UpdateCommentNoteRequest(string? Note);
 public record UpdateCommentFlagRequest(bool IsFlagged);

--- a/backend/src/Taskify.Application/Subtasks/Services/SubtaskService.cs
+++ b/backend/src/Taskify.Application/Subtasks/Services/SubtaskService.cs
@@ -42,6 +42,21 @@ public class SubtaskService
         return _subtaskRepository.ToggleSubtaskCompletion(subtaskId, isCompleted);
     }
 
+    public bool UpdateSubtaskTitle(int subtaskId, string title)
+    {
+        if (subtaskId <= 0)
+            throw new ArgumentException("Subtask ID must be positive", nameof(subtaskId));
+
+        if (string.IsNullOrWhiteSpace(title))
+            throw new ArgumentException("Subtask title cannot be empty", nameof(title));
+
+        title = title.Trim();
+        if (title.Length > 200)
+            throw new ArgumentException("Subtask title cannot exceed 200 characters", nameof(title));
+
+        return _subtaskRepository.UpdateSubtaskTitle(subtaskId, title);
+    }
+
     public bool CompleteSubtask(int subtaskId)
     {
         return _subtaskRepository.ToggleSubtaskCompletion(subtaskId, isCompleted: true);

--- a/backend/src/Taskify.Domain/Interfaces/ISubtaskRepository.cs
+++ b/backend/src/Taskify.Domain/Interfaces/ISubtaskRepository.cs
@@ -20,6 +20,11 @@ public interface ISubtaskRepository
     bool ToggleSubtaskCompletion(int subtaskId, bool isCompleted);
 
     /// <summary>
+    /// Updates the title of a local subtask.
+    /// </summary>
+    bool UpdateSubtaskTitle(int subtaskId, string title);
+
+    /// <summary>
     /// Updates the personal note for a subtask (stored locally, not in M-Files).
     /// </summary>
     void UpdateSubtaskPersonalNote(int subtaskId, string? note);

--- a/backend/src/Taskify.Infrastructure/Storage/LocalSubtaskRepository.cs
+++ b/backend/src/Taskify.Infrastructure/Storage/LocalSubtaskRepository.cs
@@ -35,6 +35,14 @@ public class LocalSubtaskRepository : ISubtaskRepository
         return _store.SetCompletion(subtaskId, isCompleted);
     }
 
+    public bool UpdateSubtaskTitle(int subtaskId, string title)
+    {
+        if (string.IsNullOrWhiteSpace(title))
+            throw new ArgumentNullException(nameof(title));
+
+        return _store.SetTitle(subtaskId, title.Trim());
+    }
+
     public void UpdateSubtaskPersonalNote(int subtaskId, string? note)
     {
         if (string.IsNullOrWhiteSpace(note))

--- a/backend/src/Taskify.Infrastructure/Storage/SubtaskStore.cs
+++ b/backend/src/Taskify.Infrastructure/Storage/SubtaskStore.cs
@@ -106,6 +106,25 @@ public class SubtaskStore
         }
     }
 
+    public bool SetTitle(int subtaskId, string title)
+    {
+        lock (_syncRoot)
+        {
+            foreach (var kvp in _model.AssignmentIdToSubtasks)
+            {
+                var item = kvp.Value.FirstOrDefault(i => i.Id == subtaskId);
+                if (item != null)
+                {
+                    item.Title = title;
+                    Persist();
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
     public bool UpdateOrder(int subtaskId, int newOrder)
     {
         lock (_syncRoot)

--- a/backend/tests/Taskify.Tests/Unit/Application/Subtasks/SubtaskServiceTests.cs
+++ b/backend/tests/Taskify.Tests/Unit/Application/Subtasks/SubtaskServiceTests.cs
@@ -45,6 +45,28 @@ public class SubtaskServiceTests
         Assert.True(ok);
         repo.Verify(r => r.ToggleSubtaskCompletion(9, true), Times.Once);
     }
+
+    [Fact]
+    public void UpdateSubtaskTitle_Forwards_Trimmed_Title_To_Repository()
+    {
+        var repo = new Mock<ISubtaskRepository>();
+        repo.Setup(r => r.UpdateSubtaskTitle(7, "Updated title")).Returns(true);
+        var service = new SubtaskService(repo.Object);
+
+        var ok = service.UpdateSubtaskTitle(7, "  Updated title  ");
+
+        Assert.True(ok);
+        repo.Verify(r => r.UpdateSubtaskTitle(7, "Updated title"), Times.Once);
+    }
+
+    [Fact]
+    public void UpdateSubtaskTitle_Validates_Empty_Title()
+    {
+        var repo = new Mock<ISubtaskRepository>(MockBehavior.Strict);
+        var service = new SubtaskService(repo.Object);
+
+        Assert.Throws<ArgumentException>(() => service.UpdateSubtaskTitle(2, " "));
+    }
 }
 
 

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -756,6 +756,23 @@
   flex: 1;
 }
 
+.subtask-title-input {
+  flex: 1;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+  color: rgba(255, 255, 255, 0.95);
+  font-size: 0.9rem;
+  padding: 0.35rem 0.5rem;
+  min-width: 140px;
+}
+
+.subtask-title-input:focus {
+  outline: none;
+  border-color: rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.12);
+}
+
 .subtask-title.completed {
   text-decoration: line-through;
   color: rgba(255, 255, 255, 0.5);
@@ -775,6 +792,50 @@
 
 .subtask-note-button:hover {
   background: rgba(255, 255, 255, 0.1);
+}
+
+.subtask-edit-button {
+  background: transparent;
+  border: none;
+  font-size: 1.05rem;
+  cursor: pointer;
+  padding: 0.25rem 0.45rem;
+  border-radius: 4px;
+  transition: all 0.2s ease;
+  flex-shrink: 0;
+}
+
+.subtask-edit-button:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.subtask-edit-save,
+.subtask-edit-cancel {
+  border: none;
+  border-radius: 5px;
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  flex-shrink: 0;
+}
+
+.subtask-edit-save {
+  background: #10b981;
+  color: white;
+}
+
+.subtask-edit-save:hover {
+  background: #059669;
+}
+
+.subtask-edit-cancel {
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.subtask-edit-cancel:hover {
+  background: rgba(255, 255, 255, 0.2);
 }
 
 .subtask-delete-button {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -20,6 +20,8 @@ function App() {
   const [newSubtaskText, setNewSubtaskText] = useState({});
   const [editingNotes, setEditingNotes] = useState({});
   const [subtaskNotes, setSubtaskNotes] = useState({});
+  const [editingSubtasks, setEditingSubtasks] = useState({});
+  const [subtaskTitleDrafts, setSubtaskTitleDrafts] = useState({});
   const [editingCommentNotes, setEditingCommentNotes] = useState({});
   const [commentNotes, setCommentNotes] = useState({});
   const [commentFlags, setCommentFlags] = useState({});
@@ -615,6 +617,71 @@ function App() {
   const handleDeleteSubtaskNote = async (subtaskId) => {
     if (window.confirm("Are you sure you want to delete this personal note?")) {
       await handleUpdateSubtaskNote(subtaskId, null);
+    }
+  };
+
+  const handleStartSubtaskEdit = (subtask) => {
+    setEditingSubtasks((prev) => ({
+      ...prev,
+      [subtask.id]: true
+    }));
+    setSubtaskTitleDrafts((prev) => ({
+      ...prev,
+      [subtask.id]: subtask.title
+    }));
+  };
+
+  const handleCancelSubtaskEdit = (subtaskId) => {
+    setEditingSubtasks((prev) => ({
+      ...prev,
+      [subtaskId]: false
+    }));
+    setSubtaskTitleDrafts((prev) => {
+      const updated = { ...prev };
+      delete updated[subtaskId];
+      return updated;
+    });
+  };
+
+  const handleSaveSubtaskTitle = async (subtaskId) => {
+    const draftTitle = (subtaskTitleDrafts[subtaskId] || "").trim();
+    if (!draftTitle) {
+      setError("Subtask title cannot be empty");
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `http://localhost:5000/api/subtasks/${subtaskId}/title`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json"
+          },
+          body: JSON.stringify({ title: draftTitle })
+        }
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(errorText || "Failed to update subtask title");
+      }
+
+      setSubtasks((prev) => {
+        const updated = {};
+        Object.keys(prev).forEach((assignmentId) => {
+          updated[assignmentId] = prev[assignmentId].map((subtask) =>
+            subtask.id === subtaskId
+              ? { ...subtask, title: draftTitle }
+              : subtask
+          );
+        });
+        return updated;
+      });
+
+      handleCancelSubtaskEdit(subtaskId);
+    } catch (err) {
+      setError(err.toString());
     }
   };
 
@@ -1408,12 +1475,106 @@ function App() {
                                                         e.stopPropagation()
                                                       }
                                                     />
-                                                    <span
-                                                      className={`subtask-title ${subtask.isCompleted ? "completed" : ""}`}
-                                                    >
-                                                      {subtask.title}
-                                                    </span>
+                                                    {editingSubtasks[
+                                                      subtask.id
+                                                    ] ? (
+                                                      <input
+                                                        type="text"
+                                                        className="subtask-title-input"
+                                                        value={
+                                                          subtaskTitleDrafts[
+                                                            subtask.id
+                                                          ] ?? ""
+                                                        }
+                                                        onChange={(e) =>
+                                                          setSubtaskTitleDrafts(
+                                                            (prev) => ({
+                                                              ...prev,
+                                                              [subtask.id]:
+                                                                e.target.value
+                                                            })
+                                                          )
+                                                        }
+                                                        onKeyDown={(e) => {
+                                                          if (e.key === "Enter") {
+                                                            e.preventDefault();
+                                                            handleSaveSubtaskTitle(
+                                                              subtask.id
+                                                            );
+                                                          } else if (
+                                                            e.key === "Escape"
+                                                          ) {
+                                                            e.preventDefault();
+                                                            handleCancelSubtaskEdit(
+                                                              subtask.id
+                                                            );
+                                                          }
+                                                        }}
+                                                        onMouseDown={(e) =>
+                                                          e.stopPropagation()
+                                                        }
+                                                        onClick={(e) =>
+                                                          e.stopPropagation()
+                                                        }
+                                                        autoFocus
+                                                      />
+                                                    ) : (
+                                                      <span
+                                                        className={`subtask-title ${subtask.isCompleted ? "completed" : ""}`}
+                                                      >
+                                                        {subtask.title}
+                                                      </span>
+                                                    )}
                                                   </label>
+                                                  {editingSubtasks[
+                                                    subtask.id
+                                                  ] ? (
+                                                    <>
+                                                      <button
+                                                        className="subtask-edit-save"
+                                                        onMouseDown={(e) =>
+                                                          e.stopPropagation()
+                                                        }
+                                                        onClick={() =>
+                                                          handleSaveSubtaskTitle(
+                                                            subtask.id
+                                                          )
+                                                        }
+                                                        title="Save title"
+                                                      >
+                                                        Save
+                                                      </button>
+                                                      <button
+                                                        className="subtask-edit-cancel"
+                                                        onMouseDown={(e) =>
+                                                          e.stopPropagation()
+                                                        }
+                                                        onClick={() =>
+                                                          handleCancelSubtaskEdit(
+                                                            subtask.id
+                                                          )
+                                                        }
+                                                        title="Cancel edit"
+                                                      >
+                                                        Cancel
+                                                      </button>
+                                                    </>
+                                                  ) : (
+                                                    <button
+                                                      className="subtask-edit-button"
+                                                      onMouseDown={(e) =>
+                                                        e.stopPropagation()
+                                                      }
+                                                      onClick={() =>
+                                                        handleStartSubtaskEdit(
+                                                          subtask
+                                                        )
+                                                      }
+                                                      title="Edit subtask"
+                                                    >
+                                                      ✏️
+                                                    </button>
+                                                  )}
                                                   <button
                                                     className="subtask-note-button"
                                                     onMouseDown={(e) =>
@@ -2237,12 +2398,102 @@ function App() {
                                                     e.stopPropagation()
                                                   }
                                                 />
-                                                <span
-                                                  className={`subtask-title ${subtask.isCompleted ? "completed" : ""}`}
-                                                >
-                                                  {subtask.title}
-                                                </span>
+                                                {editingSubtasks[subtask.id] ? (
+                                                  <input
+                                                    type="text"
+                                                    className="subtask-title-input"
+                                                    value={
+                                                      subtaskTitleDrafts[
+                                                        subtask.id
+                                                      ] ?? ""
+                                                    }
+                                                    onChange={(e) =>
+                                                      setSubtaskTitleDrafts(
+                                                        (prev) => ({
+                                                          ...prev,
+                                                          [subtask.id]:
+                                                            e.target.value
+                                                        })
+                                                      )
+                                                    }
+                                                    onKeyDown={(e) => {
+                                                      if (e.key === "Enter") {
+                                                        e.preventDefault();
+                                                        handleSaveSubtaskTitle(
+                                                          subtask.id
+                                                        );
+                                                      } else if (
+                                                        e.key === "Escape"
+                                                      ) {
+                                                        e.preventDefault();
+                                                        handleCancelSubtaskEdit(
+                                                          subtask.id
+                                                        );
+                                                      }
+                                                    }}
+                                                    onMouseDown={(e) =>
+                                                      e.stopPropagation()
+                                                    }
+                                                    onClick={(e) =>
+                                                      e.stopPropagation()
+                                                    }
+                                                    autoFocus
+                                                  />
+                                                ) : (
+                                                  <span
+                                                    className={`subtask-title ${subtask.isCompleted ? "completed" : ""}`}
+                                                  >
+                                                    {subtask.title}
+                                                  </span>
+                                                )}
                                               </label>
+                                              {editingSubtasks[subtask.id] ? (
+                                                <>
+                                                  <button
+                                                    className="subtask-edit-save"
+                                                    onMouseDown={(e) =>
+                                                      e.stopPropagation()
+                                                    }
+                                                    onClick={() =>
+                                                      handleSaveSubtaskTitle(
+                                                        subtask.id
+                                                      )
+                                                    }
+                                                    title="Save title"
+                                                  >
+                                                    Save
+                                                  </button>
+                                                  <button
+                                                    className="subtask-edit-cancel"
+                                                    onMouseDown={(e) =>
+                                                      e.stopPropagation()
+                                                    }
+                                                    onClick={() =>
+                                                      handleCancelSubtaskEdit(
+                                                        subtask.id
+                                                      )
+                                                    }
+                                                    title="Cancel edit"
+                                                  >
+                                                    Cancel
+                                                  </button>
+                                                </>
+                                              ) : (
+                                                <button
+                                                  className="subtask-edit-button"
+                                                  onMouseDown={(e) =>
+                                                    e.stopPropagation()
+                                                  }
+                                                  onClick={() =>
+                                                    handleStartSubtaskEdit(
+                                                      subtask
+                                                    )
+                                                  }
+                                                  title="Edit subtask"
+                                                >
+                                                  ✏️
+                                                </button>
+                                              )}
                                               <button
                                                 className="subtask-note-button"
                                                 onMouseDown={(e) =>


### PR DESCRIPTION
## Summary

- Add backend support for updating subtask titles via `PUT /api/subtasks/{id}/title`
- Extend subtask repository/service/store layers with title update behavior and validation
- Add unit tests for title update forwarding and empty-title validation
- Implement inline title editing UX in both subtask rendering sections (main list + Hot Zone)
- Add keyboard support: `Enter` saves and `Escape` cancels edits
- Add styling for title input and edit action buttons

## Test plan

- [x] Run backend test suite (`dotnet test backend/Taskify.sln --no-restore`)
- [x] Verify inline edit works in main assignment list
- [x] Verify inline edit works in Hot Zone list
- [x] Verify empty title is rejected
- [x] Verify `Enter` saves and `Escape` cancels

Closes #35

Made with [Cursor](https://cursor.com)