### PR TITLE
feat(assignments): add client-side assignment search

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -43,6 +43,33 @@
   gap: 1rem;
 }
 
+.assignment-search-container {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.assignment-search-input {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 8px;
+  padding: 0.7rem 0.85rem;
+  color: rgba(255, 255, 255, 0.95);
+  font-size: 0.92rem;
+  transition: all 0.2s ease;
+}
+
+.assignment-search-input:focus {
+  outline: none;
+  border-color: rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.assignment-search-input::placeholder {
+  color: rgba(255, 255, 255, 0.55);
+}
+
 .assignments-list {
   display: flex;
   flex-direction: column;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -29,6 +29,7 @@ function App() {
   const [dragOverSubtaskId, setDragOverSubtaskId] = useState(null);
   const [workingOn, setWorkingOn] = useState(new Set()); // assignmentIds that are marked as "working on"
   const [allAssignmentsCollapsed, setAllAssignmentsCollapsed] = useState(false);
+  const [assignmentSearch, setAssignmentSearch] = useState("");
 
   useEffect(() => {
     const loadInitialData = async () => {
@@ -821,17 +822,50 @@ function App() {
 
       {!loading && !error && (
         <div className="assignments-container">
+          <div className="assignment-search-container">
+            <input
+              type="text"
+              className="assignment-search-input"
+              placeholder="Search assignments..."
+              value={assignmentSearch}
+              onChange={(e) => setAssignmentSearch(e.target.value)}
+            />
+          </div>
           {assignments.length === 0 ? (
             <div className="empty-state">
               <p>No assignments found</p>
             </div>
           ) : (
             (() => {
+              const normalizedSearch = assignmentSearch.trim().toLowerCase();
+              const filteredAssignments = normalizedSearch
+                ? assignments.filter((assignment) =>
+                    [
+                      assignment.title,
+                      assignment.description,
+                      assignment.assignedTo,
+                      assignment.assigneeName
+                    ]
+                      .filter(Boolean)
+                      .some((value) =>
+                        value.toLowerCase().includes(normalizedSearch)
+                      )
+                  )
+                : assignments;
+
+              if (filteredAssignments.length === 0) {
+                return (
+                  <div className="empty-state">
+                    <p>No assignments match "{assignmentSearch}"</p>
+                  </div>
+                );
+              }
+
               // Separate working on and other assignments
-              const workingOnAssignments = assignments.filter((a) =>
+              const workingOnAssignments = filteredAssignments.filter((a) =>
                 workingOn.has(a.id)
               );
-              const otherAssignments = assignments.filter(
+              const otherAssignments = filteredAssignments.filter(
                 (a) => !workingOn.has(a.id)
               );
 


### PR DESCRIPTION
## Summary

- Add a search input at the top of the assignment board
- Filter assignments in real time (case-insensitive) by:
  - title
  - description
  - assignee fields (`assignedTo`, `assigneeName`)
- Apply filtering consistently to both Hot Zone and All Assignments sections
- Show a clear empty state when no assignments match the search term
- Add dedicated styles for the search control

## Test plan

- [x] Type into search and verify results update in real time
- [x] Verify empty search shows all assignments
- [x] Verify filtered results affect both Hot Zone and All Assignments
- [x] Verify no-match state renders correctly
- [x] Run frontend build (`npm run build`)

Closes #50

Made with [Cursor](https://cursor.com)