### PR TITLE
feat(ui): make assignment controls sticky on scroll

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -48,6 +48,16 @@
   flex-direction: column;
   gap: 0.6rem;
   margin-bottom: 0.5rem;
+  position: sticky;
+  top: 0.5rem;
+  z-index: 20;
+  padding: 0.6rem;
+  border-radius: 10px;
+  background: rgba(10, 14, 24, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.25);
 }
 
 .assignment-search-container {


### PR DESCRIPTION
## Summary

- Make assignment search/filter controls sticky while scrolling long lists
- Add floating container styling for readability (background, border, blur, shadow)
- Keep controls accessible without scrolling back to the top

## Test plan

- [x] Verify controls remain visible while scrolling down assignment cards
- [x] Verify assignment cards remain clickable/usable under sticky controls
- [x] Verify desktop and mobile layouts still render correctly
- [x] Run frontend build (`npm run build`)

Closes #54

Made with [Cursor](https://cursor.com)