### PR TITLE
fix(comments): don't flag in-app authored comments as unread

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -331,6 +331,10 @@ function App() {
       }
 
       const newComment = await response.json();
+      const baseCount =
+        commentCounts[assignmentId] ?? comments[assignmentId]?.length ?? 0;
+      const nextCount = baseCount + 1;
+
       setComments((prev) => ({
         ...prev,
         [assignmentId]: [...(prev[assignmentId] || []), newComment]
@@ -339,7 +343,12 @@ function App() {
       // Update comment count
       setCommentCounts((prev) => ({
         ...prev,
-        [assignmentId]: (prev[assignmentId] || 0) + 1
+        [assignmentId]: nextCount
+      }));
+      // Comments authored in-app are considered seen immediately.
+      setLastSeenCommentCounts((prev) => ({
+        ...prev,
+        [assignmentId]: nextCount
       }));
     } catch (err) {
       setError(err.toString());


### PR DESCRIPTION
## Summary

- Prevent unread indicators from triggering when the current user adds a comment from Taskify
- Update seen-comment count immediately after successful comment creation
- Keep unread indicators focused on externally-added/new comments

## Test plan

- [x] Add a comment from Taskify and verify unread indicator does not appear
- [x] Verify unread indicators still appear for externally-added comments
- [x] Verify unread filter/sort behavior remains correct
- [x] Run frontend build (`npm run build`)

Closes #55

Made with [Cursor](https://cursor.com)