### PR TITLE
feat(assignments): add manual refresh and auto-refresh interval controls

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -115,6 +115,44 @@
   border-color: rgba(251, 146, 60, 0.45);
 }
 
+.assignment-refresh-button {
+  background: rgba(59, 130, 246, 0.2);
+  border: 1px solid rgba(96, 165, 250, 0.45);
+  color: #bfdbfe;
+  border-radius: 999px;
+  padding: 0.35rem 0.8rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.assignment-refresh-button:hover {
+  background: rgba(59, 130, 246, 0.3);
+  border-color: rgba(147, 197, 253, 0.6);
+}
+
+.assignment-refresh-interval {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: rgba(255, 255, 255, 0.9);
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.assignment-refresh-interval:focus {
+  outline: none;
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+.assignment-refresh-meta {
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 0.75rem;
+  margin-left: 0.2rem;
+}
+
 .assignments-list {
   display: flex;
   flex-direction: column;

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -140,11 +140,19 @@
   padding: 0.35rem 0.7rem;
   font-size: 0.78rem;
   font-weight: 600;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
 }
 
 .assignment-refresh-interval:focus {
   outline: none;
   border-color: rgba(255, 255, 255, 0.35);
+}
+
+.assignment-refresh-interval option {
+  background: #0f172a;
+  color: #e5e7eb;
 }
 
 .assignment-refresh-meta {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import "./App.css";
 
 const ASSIGNMENTS_API_URL = "http://localhost:5000/api/assignments";
 const LAST_SEEN_COMMENT_COUNTS_KEY = "lastSeenCommentCounts";
 const SHOW_ONLY_UNREAD_ASSIGNMENTS_KEY = "showOnlyUnreadAssignments";
 const SORT_UNREAD_TO_TOP_KEY = "sortUnreadToTop";
+const AUTO_REFRESH_INTERVAL_SECONDS_KEY = "assignmentAutoRefreshSeconds";
 
 function App() {
   const [assignments, setAssignments] = useState([]);
@@ -59,63 +60,66 @@ function App() {
       return false;
     }
   });
-
-  useEffect(() => {
-    const loadInitialData = async () => {
+  const [autoRefreshIntervalSeconds, setAutoRefreshIntervalSeconds] = useState(
+    () => {
       try {
-        // Fetch current user and assignments in parallel, but wait for both
-        // before clearing the loading state. This guarantees currentUser is
-        // available before the UI becomes interactive.
-        const [userRes, assignmentsRes] = await Promise.all([
+        const raw = localStorage.getItem(AUTO_REFRESH_INTERVAL_SECONDS_KEY);
+        const parsed = Number(raw);
+        return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+      } catch {
+        return 0;
+      }
+    }
+  );
+  const [lastRefreshedAt, setLastRefreshedAt] = useState(null);
+
+  const refreshData = useCallback(async (isInitialLoad = false) => {
+    try {
+      const [userRes, assignmentsRes, countsRes, workingOnRes] =
+        await Promise.all([
           fetch("http://localhost:5000/api/user/current"),
-          fetch(ASSIGNMENTS_API_URL)
+          fetch(ASSIGNMENTS_API_URL),
+          fetch("http://localhost:5000/api/assignments/comments/counts"),
+          fetch("http://localhost:5000/api/assignments/working-on")
         ]);
 
-        if (userRes.ok) {
-          const userData = await userRes.json();
-          setCurrentUser(userData.userName);
-        } else {
-          console.error("Failed to fetch current user:", userRes.status);
-        }
+      if (userRes.ok) {
+        const userData = await userRes.json();
+        setCurrentUser(userData.userName);
+      }
 
-        if (!assignmentsRes.ok) throw new Error("Failed to fetch assignments");
-        const assignmentsData = await assignmentsRes.json();
-        setAssignments(assignmentsData);
-        setLoading(false);
+      if (!assignmentsRes.ok) throw new Error("Failed to fetch assignments");
+      const assignmentsData = await assignmentsRes.json();
+      setAssignments(assignmentsData);
 
-        // Fetch secondary data (comment counts, working-on flags) after core data is ready
-        fetch("http://localhost:5000/api/assignments/comments/counts")
-          .then((res) => {
-            if (!res.ok) throw new Error("Failed to fetch comment counts");
-            return res.json();
-          })
-          .then((counts) => {
-            setCommentCounts(counts);
-          })
-          .catch((err) => {
-            console.error("Error fetching comment counts:", err);
-          });
-      } catch (err) {
+      if (countsRes.ok) {
+        const counts = await countsRes.json();
+        setCommentCounts(counts);
+      }
+
+      if (workingOnRes.ok) {
+        const workingOnData = await workingOnRes.json();
+        setWorkingOn(new Set(workingOnData));
+      }
+
+      setLastRefreshedAt(new Date().toISOString());
+      setError(null);
+    } catch (err) {
+      if (isInitialLoad) {
         setError(err.toString());
+      } else {
+        console.error("Error refreshing assignment data:", err);
+      }
+    } finally {
+      if (isInitialLoad) {
         setLoading(false);
       }
-    };
-
-    loadInitialData();
-
-    // Fetch working on flags (independent, non-blocking)
-    fetch("http://localhost:5000/api/assignments/working-on")
-      .then((res) => {
-        if (res.ok) return res.json();
-        return [];
-      })
-      .then((data) => {
-        setWorkingOn(new Set(data));
-      })
-      .catch((err) => {
-        console.error("Error loading working on flags:", err);
-      });
+    }
   }, []);
+
+  useEffect(() => {
+    refreshData(true);
+  }, [refreshData]);
 
   useEffect(() => {
     try {
@@ -146,6 +150,27 @@ function App() {
       // ignore storage write failures
     }
   }, [sortUnreadToTop]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        AUTO_REFRESH_INTERVAL_SECONDS_KEY,
+        String(autoRefreshIntervalSeconds)
+      );
+    } catch {
+      // ignore storage write failures
+    }
+  }, [autoRefreshIntervalSeconds]);
+
+  useEffect(() => {
+    if (!autoRefreshIntervalSeconds) return undefined;
+
+    const intervalId = setInterval(() => {
+      refreshData(false);
+    }, autoRefreshIntervalSeconds * 1000);
+
+    return () => clearInterval(intervalId);
+  }, [autoRefreshIntervalSeconds, refreshData]);
 
   useEffect(() => {
     // Initialize unseen assignments so badges only represent comments
@@ -957,6 +982,32 @@ function App() {
               >
                 {sortUnreadToTop ? "Sort: Unread first" : "Sort: Default"}
               </button>
+              <button
+                className="assignment-refresh-button"
+                onClick={() => refreshData(false)}
+                title="Refresh assignments"
+              >
+                Refresh
+              </button>
+              <select
+                className="assignment-refresh-interval"
+                value={autoRefreshIntervalSeconds}
+                onChange={(e) =>
+                  setAutoRefreshIntervalSeconds(Number(e.target.value))
+                }
+                title="Auto-refresh interval"
+              >
+                <option value={0}>Auto-refresh: Off</option>
+                <option value={30}>Auto-refresh: 30s</option>
+                <option value={60}>Auto-refresh: 60s</option>
+                <option value={120}>Auto-refresh: 120s</option>
+              </select>
+            </div>
+            <div className="assignment-refresh-meta">
+              Last refreshed:{" "}
+              {lastRefreshedAt
+                ? new Date(lastRefreshedAt).toLocaleTimeString()
+                : "Not yet"}
             </div>
           </div>
           {assignments.length === 0 ? (


### PR DESCRIPTION
## Summary

- Refactor assignment loading into reusable `refreshData()`
- Add **Refresh** button to reload board data on demand
- Add configurable auto-refresh interval selector: `Off`, `30s`, `60s`, `120s`
- Persist auto-refresh preference in localStorage
- Show "Last refreshed" timestamp in the controls area
- Keep refresh behavior non-disruptive by refreshing board-level datasets only

## Test plan

- [x] Verify Refresh button reloads assignments/comment counts/working-on flags
- [x] Verify auto-refresh runs at selected interval and stops when set to Off
- [x] Verify auto-refresh preference persists across reload
- [x] Verify last refreshed timestamp updates after refresh
- [x] Run frontend build (`npm run build`)

Closes #58

Made with [Cursor](https://cursor.com)