### PR TITLE
feat(attachments): complete M-Files support and add attachment previews

### DIFF
--- a/backend/src/Taskify.Api/Program.cs
+++ b/backend/src/Taskify.Api/Program.cs
@@ -138,6 +138,63 @@ app.MapGet("api/assignments/working-on", (WorkingOnService svc) =>
     return Results.Ok(workingOnIds.ToList());
 });
 
+// ─── Attachments ───
+app.MapGet("api/assignments/{id:int}/attachments", async (int id, ITaskDataSource ds) =>
+{
+    try
+    {
+        var attachments = await ds.GetAttachmentsForTaskAsync(id.ToString());
+        return Results.Ok(attachments);
+    }
+    catch (Exception ex)
+    {
+        return Results.BadRequest($"Error getting attachments: {ex.Message}");
+    }
+});
+app.MapPost("api/assignments/{id:int}/attachments", async (int id, ITaskDataSource ds, HttpRequest req) =>
+{
+    if (!req.HasFormContentType)
+        return Results.BadRequest("multipart/form-data required");
+
+    var form = await req.ReadFormAsync();
+    var file = form.Files.FirstOrDefault();
+    if (file == null || file.Length == 0)
+        return Results.BadRequest("file is required");
+
+    await using var stream = file.OpenReadStream();
+    using var ms = new MemoryStream();
+    await stream.CopyToAsync(ms);
+
+    try
+    {
+        var attachment = await ds.AddAttachmentAsync(
+            id.ToString(),
+            file.FileName,
+            file.ContentType ?? "application/octet-stream",
+            ms.ToArray());
+        return Results.Ok(attachment);
+    }
+    catch (Exception ex)
+    {
+        return Results.BadRequest($"Error adding attachment: {ex.Message}");
+    }
+});
+app.MapGet("api/assignments/{id:int}/attachments/{attachmentId}/download", async (int id, string attachmentId, ITaskDataSource ds) =>
+{
+    try
+    {
+        var file = await ds.GetAttachmentFileAsync(id.ToString(), attachmentId);
+        if (file == null)
+            return Results.NotFound();
+
+        return Results.File(file.Content, file.ContentType, file.FileName);
+    }
+    catch (Exception ex)
+    {
+        return Results.BadRequest($"Error downloading attachment: {ex.Message}");
+    }
+});
+
 // ─── Comments ───
 app.MapGet("api/assignments/{id:int}/comments", (int id, CommentService svc) =>
     Results.Ok(svc.GetAssignmentComments(id)));

--- a/backend/src/Taskify.Connectors/ITaskDataSource.cs
+++ b/backend/src/Taskify.Connectors/ITaskDataSource.cs
@@ -57,4 +57,25 @@ public interface ITaskDataSource
     /// Gets the count of comments for a task/assignment.
     /// </summary>
     Task<int> GetCommentCountAsync(string taskId);
+
+    // ── Attachments ──
+
+    /// <summary>
+    /// Retrieves attachment metadata for a specific task/assignment.
+    /// </summary>
+    Task<IReadOnlyList<AttachmentDTO>> GetAttachmentsForTaskAsync(string taskId);
+
+    /// <summary>
+    /// Adds an attachment to a specific task/assignment in the source system.
+    /// </summary>
+    Task<AttachmentDTO> AddAttachmentAsync(
+        string taskId,
+        string fileName,
+        string contentType,
+        byte[] content);
+
+    /// <summary>
+    /// Downloads an attachment payload for a specific task/assignment.
+    /// </summary>
+    Task<AttachmentFileDTO?> GetAttachmentFileAsync(string taskId, string attachmentId);
 }

--- a/backend/src/Taskify.Connectors/MFiles/MFilesConnector.cs
+++ b/backend/src/Taskify.Connectors/MFiles/MFilesConnector.cs
@@ -344,6 +344,32 @@ public class MFilesConnector : ITaskDataSource, IDisposable
         }
     }
 
+    public Task<IReadOnlyList<AttachmentDTO>> GetAttachmentsForTaskAsync(string taskId)
+    {
+        // TODO(#37): Implement native M-Files attachment listing.
+        // For now we return an empty list to keep API shape stable and
+        // enable frontend work with the Mock connector.
+        return Task.FromResult<IReadOnlyList<AttachmentDTO>>(new List<AttachmentDTO>());
+    }
+
+    public Task<AttachmentDTO> AddAttachmentAsync(
+        string taskId,
+        string fileName,
+        string contentType,
+        byte[] content)
+    {
+        throw new NotSupportedException(
+            "Attachment upload is not yet implemented for MFilesConnector. " +
+            "Use Mock connector for attachment workflow testing.");
+    }
+
+    public Task<AttachmentFileDTO?> GetAttachmentFileAsync(string taskId, string attachmentId)
+    {
+        throw new NotSupportedException(
+            "Attachment download is not yet implemented for MFilesConnector. " +
+            "Use Mock connector for attachment workflow testing.");
+    }
+
     // ── Comment Helpers ──
 
     private static CommentDTO? ParseCommentLine(string line, int assignmentId, int commentId)

--- a/backend/src/Taskify.Connectors/MFiles/MFilesConnector.cs
+++ b/backend/src/Taskify.Connectors/MFiles/MFilesConnector.cs
@@ -346,10 +346,55 @@ public class MFilesConnector : ITaskDataSource, IDisposable
 
     public Task<IReadOnlyList<AttachmentDTO>> GetAttachmentsForTaskAsync(string taskId)
     {
-        // TODO(#37): Implement native M-Files attachment listing.
-        // For now we return an empty list to keep API shape stable and
-        // enable frontend work with the Mock connector.
-        return Task.FromResult<IReadOnlyList<AttachmentDTO>>(new List<AttachmentDTO>());
+        if (!int.TryParse(taskId, out var assignmentId))
+            return Task.FromResult<IReadOnlyList<AttachmentDTO>>(new List<AttachmentDTO>());
+
+        try
+        {
+            var vault = GetVault();
+
+            var objID = new ObjID();
+            objID.SetIDs(
+                ObjType: (int)MFBuiltInObjectType.MFBuiltInObjectTypeAssignment,
+                ID: assignmentId);
+
+            var latestObjVer = vault.ObjectOperations.GetLatestObjVer(objID, AllowCheckedOut: true);
+            var files = vault.ObjectFileOperations.GetFiles(latestObjVer);
+
+            var attachments = new List<AttachmentDTO>();
+            for (int i = 1; i <= files.Count; i++)
+            {
+                var file = files[i];
+                var fileName = string.IsNullOrWhiteSpace(file.Extension)
+                    ? file.Title
+                    : $"{file.Title}.{file.Extension}";
+
+                long sizeBytes = 0;
+                try
+                {
+                    sizeBytes = vault.ObjectFileOperations.GetFileSizeEx(objID, file.FileVer);
+                }
+                catch
+                {
+                    try { sizeBytes = vault.ObjectFileOperations.GetFileSize(file.FileVer); } catch { }
+                }
+
+                attachments.Add(new AttachmentDTO
+                {
+                    Id = file.ID.ToString(),
+                    FileName = fileName,
+                    ContentType = GetContentTypeFromFileName(fileName),
+                    SizeBytes = sizeBytes
+                });
+            }
+
+            return Task.FromResult<IReadOnlyList<AttachmentDTO>>(attachments);
+        }
+        catch (Exception ex)
+        {
+            throw new ApplicationException(
+                $"Failed to retrieve attachments for assignment {assignmentId}: {ex.Message}", ex);
+        }
     }
 
     public Task<AttachmentDTO> AddAttachmentAsync(
@@ -358,16 +403,154 @@ public class MFilesConnector : ITaskDataSource, IDisposable
         string contentType,
         byte[] content)
     {
-        throw new NotSupportedException(
-            "Attachment upload is not yet implemented for MFilesConnector. " +
-            "Use Mock connector for attachment workflow testing.");
+        if (!int.TryParse(taskId, out var assignmentId))
+            throw new ArgumentException("Invalid task ID", nameof(taskId));
+
+        if (string.IsNullOrWhiteSpace(fileName))
+            throw new ArgumentException("File name is required", nameof(fileName));
+
+        var extension = Path.GetExtension(fileName).TrimStart('.');
+        if (string.IsNullOrWhiteSpace(extension))
+            extension = "bin";
+
+        var title = Path.GetFileNameWithoutExtension(fileName);
+        if (string.IsNullOrWhiteSpace(title))
+            title = fileName;
+
+        var tempPath = Path.Combine(
+            Path.GetTempPath(),
+            $"{Guid.NewGuid()}_{SanitizeFileName(fileName)}");
+
+        try
+        {
+            File.WriteAllBytes(tempPath, content ?? Array.Empty<byte>());
+
+            var vault = GetVault();
+
+            var objID = new ObjID();
+            objID.SetIDs(
+                ObjType: (int)MFBuiltInObjectType.MFBuiltInObjectTypeAssignment,
+                ID: assignmentId);
+
+            var checkedOutVersion = vault.ObjectOperations.CheckOut(objID);
+            try
+            {
+                var addedFileVer = vault.ObjectFileOperations.AddFile(
+                    checkedOutVersion.ObjVer,
+                    title,
+                    extension,
+                    tempPath);
+
+                vault.ObjectOperations.CheckIn(checkedOutVersion.ObjVer);
+
+                var addedFileName = $"{title}.{extension}";
+                var result = new AttachmentDTO
+                {
+                    Id = addedFileVer.ID.ToString(),
+                    FileName = addedFileName,
+                    ContentType = string.IsNullOrWhiteSpace(contentType)
+                        ? GetContentTypeFromFileName(addedFileName)
+                        : contentType,
+                    SizeBytes = content?.LongLength ?? 0
+                };
+
+                return Task.FromResult(result);
+            }
+            catch
+            {
+                try { vault.ObjectOperations.UndoCheckout(checkedOutVersion.ObjVer); } catch { }
+                throw;
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new ApplicationException(
+                $"Failed to add attachment to assignment {assignmentId}: {ex.Message}", ex);
+        }
+        finally
+        {
+            try { if (File.Exists(tempPath)) File.Delete(tempPath); } catch { }
+        }
     }
 
     public Task<AttachmentFileDTO?> GetAttachmentFileAsync(string taskId, string attachmentId)
     {
-        throw new NotSupportedException(
-            "Attachment download is not yet implemented for MFilesConnector. " +
-            "Use Mock connector for attachment workflow testing.");
+        if (!int.TryParse(taskId, out var assignmentId))
+            return Task.FromResult<AttachmentFileDTO?>(null);
+        if (!int.TryParse(attachmentId, out var fileId))
+            return Task.FromResult<AttachmentFileDTO?>(null);
+
+        try
+        {
+            var vault = GetVault();
+
+            var objID = new ObjID();
+            objID.SetIDs(
+                ObjType: (int)MFBuiltInObjectType.MFBuiltInObjectTypeAssignment,
+                ID: assignmentId);
+
+            var latestObjVer = vault.ObjectOperations.GetLatestObjVer(objID, AllowCheckedOut: true);
+            var files = vault.ObjectFileOperations.GetFiles(latestObjVer);
+
+            ObjectFile? targetFile = null;
+            for (int i = 1; i <= files.Count; i++)
+            {
+                var file = files[i];
+                if (file.ID == fileId)
+                {
+                    targetFile = file;
+                    break;
+                }
+            }
+
+            if (targetFile == null)
+                return Task.FromResult<AttachmentFileDTO?>(null);
+
+            var dataUri = vault.ObjectFileOperations.DownloadFileAsDataURIEx(
+                latestObjVer,
+                targetFile.FileVer);
+            if (string.IsNullOrWhiteSpace(dataUri))
+                return Task.FromResult<AttachmentFileDTO?>(null);
+
+            var commaIndex = dataUri.IndexOf(',');
+            if (commaIndex <= 0)
+                throw new ApplicationException("M-Files returned an invalid data URI payload.");
+
+            var metadata = dataUri.Substring(0, commaIndex);
+            var payload = dataUri[(commaIndex + 1)..];
+            var isBase64 = metadata.Contains(";base64", StringComparison.OrdinalIgnoreCase);
+
+            var fileName = string.IsNullOrWhiteSpace(targetFile.Extension)
+                ? targetFile.Title
+                : $"{targetFile.Title}.{targetFile.Extension}";
+
+            var mimeType = GetContentTypeFromFileName(fileName);
+            if (metadata.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+            {
+                var contentTypePart = metadata["data:".Length..].Split(';')[0];
+                if (!string.IsNullOrWhiteSpace(contentTypePart))
+                    mimeType = contentTypePart;
+            }
+
+            var bytes = isBase64
+                ? Convert.FromBase64String(payload)
+                : System.Text.Encoding.UTF8.GetBytes(Uri.UnescapeDataString(payload));
+
+            var dto = new AttachmentFileDTO
+            {
+                Id = targetFile.ID.ToString(),
+                FileName = fileName,
+                ContentType = mimeType,
+                Content = bytes
+            };
+
+            return Task.FromResult<AttachmentFileDTO?>(dto);
+        }
+        catch (Exception ex)
+        {
+            throw new ApplicationException(
+                $"Failed to download attachment {attachmentId} for assignment {assignmentId}: {ex.Message}", ex);
+        }
     }
 
     // ── Comment Helpers ──
@@ -432,6 +615,44 @@ public class MFilesConnector : ITaskDataSource, IDisposable
         propertyValue.TypedValue.SetValue(MFDataType.MFDatatypeMultiLineText, newText);
 
         existingProperty!.TypedValue = propertyValue.TypedValue;
+    }
+
+    private static string GetContentTypeFromFileName(string fileName)
+    {
+        var ext = Path.GetExtension(fileName).ToLowerInvariant();
+        return ext switch
+        {
+            ".pdf" => "application/pdf",
+            ".txt" => "text/plain",
+            ".csv" => "text/csv",
+            ".json" => "application/json",
+            ".xml" => "application/xml",
+            ".doc" => "application/msword",
+            ".docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            ".xls" => "application/vnd.ms-excel",
+            ".xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            ".ppt" => "application/vnd.ms-powerpoint",
+            ".pptx" => "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            ".png" => "image/png",
+            ".jpg" or ".jpeg" => "image/jpeg",
+            ".gif" => "image/gif",
+            ".zip" => "application/zip",
+            _ => "application/octet-stream"
+        };
+    }
+
+    private static string SanitizeFileName(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+            return "file.bin";
+
+        var sanitized = fileName;
+        foreach (var invalid in Path.GetInvalidFileNameChars())
+        {
+            sanitized = sanitized.Replace(invalid, '_');
+        }
+
+        return string.IsNullOrWhiteSpace(sanitized) ? "file.bin" : sanitized;
     }
 
     // ── Connection ──

--- a/backend/src/Taskify.Connectors/Mock/MockConnector.cs
+++ b/backend/src/Taskify.Connectors/Mock/MockConnector.cs
@@ -9,12 +9,15 @@ public class MockConnector : ITaskDataSource
 {
     private readonly List<TaskDTO> _tasks;
     private readonly Dictionary<string, List<CommentDTO>> _comments;
+    private readonly Dictionary<string, List<AttachmentFileDTO>> _attachments;
     private int _nextCommentId = 100;
+    private int _nextAttachmentId = 1000;
 
     public MockConnector()
     {
         _tasks = GenerateMockTasks();
         _comments = GenerateMockComments();
+        _attachments = GenerateMockAttachments();
     }
 
     public async Task<IReadOnlyList<TaskDTO>> GetAllTasksAsync()
@@ -93,6 +96,65 @@ public class MockConnector : ITaskDataSource
     {
         await Task.Delay(50);
         return _comments.TryGetValue(taskId, out var comments) ? comments.Count : 0;
+    }
+
+    public async Task<IReadOnlyList<AttachmentDTO>> GetAttachmentsForTaskAsync(string taskId)
+    {
+        await Task.Delay(80);
+        if (!_attachments.TryGetValue(taskId, out var files))
+            return new List<AttachmentDTO>().AsReadOnly();
+
+        return files
+            .Select(f => new AttachmentDTO
+            {
+                Id = f.Id,
+                FileName = f.FileName,
+                ContentType = f.ContentType,
+                SizeBytes = f.Content.LongLength
+            })
+            .ToList()
+            .AsReadOnly();
+    }
+
+    public Task<AttachmentDTO> AddAttachmentAsync(
+        string taskId,
+        string fileName,
+        string contentType,
+        byte[] content)
+    {
+        if (!_attachments.ContainsKey(taskId))
+            _attachments[taskId] = new List<AttachmentFileDTO>();
+
+        var file = new AttachmentFileDTO
+        {
+            Id = (_nextAttachmentId++).ToString(),
+            FileName = fileName,
+            ContentType = string.IsNullOrWhiteSpace(contentType)
+                ? "application/octet-stream"
+                : contentType,
+            Content = content ?? Array.Empty<byte>()
+        };
+
+        _attachments[taskId].Add(file);
+
+        var dto = new AttachmentDTO
+        {
+            Id = file.Id,
+            FileName = file.FileName,
+            ContentType = file.ContentType,
+            SizeBytes = file.Content.LongLength
+        };
+
+        return Task.FromResult(dto);
+    }
+
+    public Task<AttachmentFileDTO?> GetAttachmentFileAsync(string taskId, string attachmentId)
+    {
+        if (!_attachments.TryGetValue(taskId, out var files))
+            return Task.FromResult<AttachmentFileDTO?>(null);
+
+        var file = files.FirstOrDefault(f => f.Id == attachmentId);
+        return Task.FromResult(file);
     }
 
     /// <summary>
@@ -269,6 +331,33 @@ public class MockConnector : ITaskDataSource
             {
                 new CommentDTO { Id = 7, Content = "Pipeline is live on staging. All tests green.", AuthorName = "Lebo", CreatedDate = now.AddHours(-2), AssignmentId = 1007 },
                 new CommentDTO { Id = 8, Content = "Great work! Verified deployment works end to end.", AuthorName = "Sarah", CreatedDate = now.AddHours(-1), AssignmentId = 1007 }
+            }
+        };
+    }
+
+    private static Dictionary<string, List<AttachmentFileDTO>> GenerateMockAttachments()
+    {
+        return new Dictionary<string, List<AttachmentFileDTO>>
+        {
+            ["1001"] = new List<AttachmentFileDTO>
+            {
+                new AttachmentFileDTO
+                {
+                    Id = "501",
+                    FileName = "api-auth-flow-notes.txt",
+                    ContentType = "text/plain",
+                    Content = System.Text.Encoding.UTF8.GetBytes("Auth flow implementation notes")
+                }
+            },
+            ["1003"] = new List<AttachmentFileDTO>
+            {
+                new AttachmentFileDTO
+                {
+                    Id = "502",
+                    FileName = "shipping-api-contract.pdf",
+                    ContentType = "application/pdf",
+                    Content = System.Text.Encoding.UTF8.GetBytes("%PDF-1.4 mock content")
+                }
             }
         };
     }

--- a/backend/src/Taskify.Connectors/Models/AttachmentDTO.cs
+++ b/backend/src/Taskify.Connectors/Models/AttachmentDTO.cs
@@ -1,0 +1,23 @@
+namespace Taskify.Connectors;
+
+/// <summary>
+/// Normalized attachment metadata from the source system.
+/// </summary>
+public class AttachmentDTO
+{
+    public string Id { get; set; } = string.Empty;
+    public string FileName { get; set; } = string.Empty;
+    public string ContentType { get; set; } = "application/octet-stream";
+    public long SizeBytes { get; set; }
+}
+
+/// <summary>
+/// Attachment payload used when downloading attachment content.
+/// </summary>
+public class AttachmentFileDTO
+{
+    public string Id { get; set; } = string.Empty;
+    public string FileName { get; set; } = string.Empty;
+    public string ContentType { get; set; } = "application/octet-stream";
+    public byte[] Content { get; set; } = Array.Empty<byte>();
+}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "mammoth": "^1.12.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -1421,6 +1422,15 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1491,6 +1501,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.24",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.24.tgz",
@@ -1500,6 +1530,12 @@
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -1628,6 +1664,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1674,6 +1716,21 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dingbat-to-unicode": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
+      "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/duck": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/duck/-/duck-0.1.12.tgz",
+      "integrity": "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==",
+      "license": "BSD",
+      "dependencies": {
+        "underscore": "^1.13.1"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.245",
@@ -2085,6 +2142,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2112,6 +2175,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2134,6 +2203,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2209,6 +2284,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -2231,6 +2318,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/locate-path": {
@@ -2256,6 +2352,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lop": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/lop/-/lop-0.4.2.tgz",
+      "integrity": "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "duck": "^0.1.12",
+        "option": "~0.2.1",
+        "underscore": "^1.13.1"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2264,6 +2371,39 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/mammoth": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.12.0.tgz",
+      "integrity": "sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.6",
+        "argparse": "~1.0.3",
+        "base64-js": "^1.5.1",
+        "bluebird": "~3.4.0",
+        "dingbat-to-unicode": "^1.0.1",
+        "jszip": "^3.7.1",
+        "lop": "^0.4.2",
+        "path-is-absolute": "^1.0.0",
+        "underscore": "^1.13.1",
+        "xmlbuilder": "^10.0.0"
+      },
+      "bin": {
+        "mammoth": "bin/mammoth"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/mammoth/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/minimatch": {
@@ -2319,6 +2459,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/option": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/option/-/option-0.2.4.tgz",
+      "integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -2369,6 +2515,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2390,6 +2542,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -2461,6 +2622,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2500,6 +2667,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/resolve-from": {
@@ -2554,6 +2736,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -2569,6 +2757,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -2601,6 +2795,21 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/strip-json-comments": {
@@ -2659,6 +2868,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "license": "MIT"
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
@@ -2699,6 +2914,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.2.0",
@@ -2799,6 +3020,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+      "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/yallist": {

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "mammoth": "^1.12.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -501,6 +501,13 @@
   padding: 0.45rem 0.65rem;
 }
 
+.attachment-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-width: 0;
+}
+
 .attachment-link {
   background: transparent;
   border: none;
@@ -514,6 +521,29 @@
 
 .attachment-link:hover {
   color: #bfdbfe;
+}
+
+.attachment-preview-button {
+  background: rgba(56, 189, 248, 0.18);
+  border: 1px solid rgba(56, 189, 248, 0.45);
+  color: #bae6fd;
+  border-radius: 6px;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.74rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+}
+
+.attachment-preview-button:hover:not(:disabled) {
+  background: rgba(56, 189, 248, 0.28);
+  border-color: rgba(125, 211, 252, 0.7);
+}
+
+.attachment-preview-button:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
 }
 
 .attachment-size {
@@ -538,6 +568,110 @@
 .attachment-uploading {
   color: rgba(255, 255, 255, 0.6);
   font-size: 0.8rem;
+}
+
+.attachment-preview-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  background: rgba(2, 6, 23, 0.78);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.attachment-preview-modal {
+  width: min(960px, 95vw);
+  max-height: 90vh;
+  background: #0f172a;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 12px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.attachment-preview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.attachment-preview-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.attachment-preview-close {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  color: rgba(255, 255, 255, 0.92);
+  border-radius: 8px;
+  padding: 0.35rem 0.65rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.attachment-preview-content {
+  padding: 1rem;
+  overflow: auto;
+  min-height: 220px;
+}
+
+.attachment-preview-image {
+  max-width: 100%;
+  max-height: calc(90vh - 150px);
+  border-radius: 8px;
+  display: block;
+  margin: 0 auto;
+}
+
+.attachment-preview-pdf {
+  width: 100%;
+  height: calc(90vh - 180px);
+  min-height: 420px;
+  border: none;
+  border-radius: 8px;
+  background: #111827;
+}
+
+.attachment-preview-text {
+  margin: 0;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 0.85rem;
+  color: rgba(255, 255, 255, 0.88);
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.attachment-preview-docx {
+  background: #ffffff;
+  color: #111827;
+  border-radius: 8px;
+  padding: 1rem;
+  line-height: 1.5;
+}
+
+.attachment-preview-docx p {
+  margin: 0 0 0.8rem 0;
+}
+
+.attachment-preview-unsupported {
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 0.9rem;
 }
 
 .comments-filters {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -437,6 +437,23 @@
   border-color: rgba(255, 255, 255, 0.3);
 }
 
+.attachments-button {
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.attachments-button:hover {
+  background: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
 .comments-new-indicator {
   background: rgba(239, 68, 68, 0.2);
   color: #fca5a5;
@@ -453,6 +470,74 @@
   margin-top: 1rem;
   padding-top: 1rem;
   border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.attachments-section {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.attachments-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.attachments-loading,
+.attachments-empty {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.85rem;
+}
+
+.attachment-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  padding: 0.45rem 0.65rem;
+}
+
+.attachment-link {
+  background: transparent;
+  border: none;
+  color: #93c5fd;
+  font-size: 0.86rem;
+  text-align: left;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.attachment-link:hover {
+  color: #bfdbfe;
+}
+
+.attachment-size {
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+
+.attachment-upload-container {
+  margin-top: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.attachment-upload-input {
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 0.82rem;
+}
+
+.attachment-uploading {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.8rem;
 }
 
 .comments-filters {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -14,6 +14,10 @@ function App() {
   const [openComments, setOpenComments] = useState({});
   const [comments, setComments] = useState({});
   const [loadingComments, setLoadingComments] = useState({});
+  const [openAttachments, setOpenAttachments] = useState({});
+  const [attachments, setAttachments] = useState({});
+  const [loadingAttachments, setLoadingAttachments] = useState({});
+  const [uploadingAttachment, setUploadingAttachment] = useState({});
   const [newCommentText, setNewCommentText] = useState({});
   const [currentUser, setCurrentUser] = useState(null);
   const [commentCounts, setCommentCounts] = useState({});
@@ -375,6 +379,88 @@ function App() {
         ...prev,
         [assignmentId]: nextCount
       }));
+    } catch (err) {
+      setError(err.toString());
+    }
+  };
+
+  const toggleAttachments = async (assignmentId) => {
+    const isOpen = openAttachments[assignmentId];
+    setOpenAttachments((prev) => ({
+      ...prev,
+      [assignmentId]: !isOpen
+    }));
+
+    if (!isOpen && !attachments[assignmentId]) {
+      setLoadingAttachments((prev) => ({ ...prev, [assignmentId]: true }));
+      try {
+        const response = await fetch(
+          `${ASSIGNMENTS_API_URL}/${assignmentId}/attachments`
+        );
+        if (!response.ok) throw new Error("Failed to fetch attachments");
+        const data = await response.json();
+        setAttachments((prev) => ({ ...prev, [assignmentId]: data }));
+      } catch (err) {
+        setError(err.toString());
+      } finally {
+        setLoadingAttachments((prev) => ({ ...prev, [assignmentId]: false }));
+      }
+    }
+  };
+
+  const handleUploadAttachment = async (assignmentId, file) => {
+    if (!file) return;
+
+    setUploadingAttachment((prev) => ({ ...prev, [assignmentId]: true }));
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+
+      const response = await fetch(
+        `${ASSIGNMENTS_API_URL}/${assignmentId}/attachments`,
+        {
+          method: "POST",
+          body: formData
+        }
+      );
+
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || "Failed to upload attachment");
+      }
+
+      const uploaded = await response.json();
+      setAttachments((prev) => ({
+        ...prev,
+        [assignmentId]: [...(prev[assignmentId] || []), uploaded]
+      }));
+    } catch (err) {
+      setError(err.toString());
+    } finally {
+      setUploadingAttachment((prev) => ({ ...prev, [assignmentId]: false }));
+    }
+  };
+
+  const handleDownloadAttachment = async (assignmentId, attachment) => {
+    try {
+      const response = await fetch(
+        `${ASSIGNMENTS_API_URL}/${assignmentId}/attachments/${attachment.id}/download`
+      );
+
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || "Failed to download attachment");
+      }
+
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = attachment.fileName || "attachment";
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      window.URL.revokeObjectURL(url);
     } catch (err) {
       setError(err.toString());
     }
@@ -1191,6 +1277,15 @@ function App() {
                                   ? "Hide"
                                   : "Subtasks"}
                               </button>
+                              <button
+                                className="attachments-button"
+                                onClick={() => toggleAttachments(assignment.id)}
+                              >
+                                📎 {attachments[assignment.id]?.length || 0}{" "}
+                                {openAttachments[assignment.id]
+                                  ? "Hide"
+                                  : "Attachments"}
+                              </button>
                               {assignment.status !== 2 && (
                                 <button
                                   className="complete-button"
@@ -1661,6 +1756,77 @@ function App() {
                                   >
                                     Post
                                   </button>
+                                </div>
+                              </div>
+                            )}
+
+                            {/* Attachments Section */}
+                            {openAttachments[assignment.id] && (
+                              <div className="attachments-section">
+                                <div className="attachments-list">
+                                  {loadingAttachments[assignment.id] ? (
+                                    <div className="attachments-loading">
+                                      Loading attachments...
+                                    </div>
+                                  ) : (attachments[assignment.id] || []).length >
+                                    0 ? (
+                                    (attachments[assignment.id] || []).map(
+                                      (attachment) => (
+                                        <div
+                                          key={attachment.id}
+                                          className="attachment-item"
+                                        >
+                                          <button
+                                            className="attachment-link"
+                                            onClick={() =>
+                                              handleDownloadAttachment(
+                                                assignment.id,
+                                                attachment
+                                              )
+                                            }
+                                            title={`Download ${attachment.fileName}`}
+                                          >
+                                            {attachment.fileName}
+                                          </button>
+                                          <span className="attachment-size">
+                                            {Math.max(
+                                              1,
+                                              Math.round(
+                                                attachment.sizeBytes / 1024
+                                              )
+                                            )}{" "}
+                                            KB
+                                          </span>
+                                        </div>
+                                      )
+                                    )
+                                  ) : (
+                                    <div className="attachments-empty">
+                                      No attachments yet.
+                                    </div>
+                                  )}
+                                </div>
+                                <div className="attachment-upload-container">
+                                  <input
+                                    type="file"
+                                    className="attachment-upload-input"
+                                    onChange={(e) => {
+                                      const file = e.target.files?.[0];
+                                      if (file) {
+                                        handleUploadAttachment(
+                                          assignment.id,
+                                          file
+                                        );
+                                        e.target.value = "";
+                                      }
+                                    }}
+                                    disabled={uploadingAttachment[assignment.id]}
+                                  />
+                                  {uploadingAttachment[assignment.id] && (
+                                    <span className="attachment-uploading">
+                                      Uploading...
+                                    </span>
+                                  )}
                                 </div>
                               </div>
                             )}
@@ -2163,6 +2329,15 @@ function App() {
                               0}{" "}
                             {openSubtasks[assignment.id] ? "Hide" : "Subtasks"}
                           </button>
+                          <button
+                            className="attachments-button"
+                            onClick={() => toggleAttachments(assignment.id)}
+                          >
+                            📎 {attachments[assignment.id]?.length || 0}{" "}
+                            {openAttachments[assignment.id]
+                              ? "Hide"
+                              : "Attachments"}
+                          </button>
                           {assignment.status !== 2 && (
                             <button
                               className="complete-button"
@@ -2607,6 +2782,73 @@ function App() {
                               >
                                 Post
                               </button>
+                            </div>
+                          </div>
+                        )}
+
+                        {openAttachments[assignment.id] && (
+                          <div className="attachments-section">
+                            <div className="attachments-list">
+                              {loadingAttachments[assignment.id] ? (
+                                <div className="attachments-loading">
+                                  Loading attachments...
+                                </div>
+                              ) : (attachments[assignment.id] || []).length >
+                                0 ? (
+                                (attachments[assignment.id] || []).map(
+                                  (attachment) => (
+                                    <div
+                                      key={attachment.id}
+                                      className="attachment-item"
+                                    >
+                                      <button
+                                        className="attachment-link"
+                                        onClick={() =>
+                                          handleDownloadAttachment(
+                                            assignment.id,
+                                            attachment
+                                          )
+                                        }
+                                        title={`Download ${attachment.fileName}`}
+                                      >
+                                        {attachment.fileName}
+                                      </button>
+                                      <span className="attachment-size">
+                                        {Math.max(
+                                          1,
+                                          Math.round(
+                                            attachment.sizeBytes / 1024
+                                          )
+                                        )}{" "}
+                                        KB
+                                      </span>
+                                    </div>
+                                  )
+                                )
+                              ) : (
+                                <div className="attachments-empty">
+                                  No attachments yet.
+                                </div>
+                              )}
+                            </div>
+                            <div className="attachment-upload-container">
+                              <input
+                                type="file"
+                                className="attachment-upload-input"
+                                onChange={(e) => {
+                                  const file = e.target.files?.[0];
+                                  if (file) {
+                                    handleUploadAttachment(assignment.id, file);
+                                    e.target.value = "";
+                                  }
+                                }}
+                                disabled={uploadingAttachment[assignment.id]}
+                              />
+                              {uploadingAttachment[assignment.id] && (
+                                <span className="attachment-uploading">
+                                  Uploading...
+                                </span>
+                              )}
                             </div>
                           </div>
                         )}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -16,8 +16,11 @@ function App() {
   const [loadingComments, setLoadingComments] = useState({});
   const [openAttachments, setOpenAttachments] = useState({});
   const [attachments, setAttachments] = useState({});
+  const [attachmentCounts, setAttachmentCounts] = useState({});
   const [loadingAttachments, setLoadingAttachments] = useState({});
   const [uploadingAttachment, setUploadingAttachment] = useState({});
+  const [previewingAttachment, setPreviewingAttachment] = useState(false);
+  const [attachmentPreview, setAttachmentPreview] = useState(null);
   const [newCommentText, setNewCommentText] = useState({});
   const [currentUser, setCurrentUser] = useState(null);
   const [commentCounts, setCommentCounts] = useState({});
@@ -95,6 +98,36 @@ function App() {
       if (!assignmentsRes.ok) throw new Error("Failed to fetch assignments");
       const assignmentsData = await assignmentsRes.json();
       setAssignments(assignmentsData);
+
+      // Preload attachment counts so badges are correct without opening panels.
+      const attachmentSettled = await Promise.allSettled(
+        assignmentsData.map(async (assignment) => {
+          const response = await fetch(
+            `${ASSIGNMENTS_API_URL}/${assignment.id}/attachments`
+          );
+          if (!response.ok) {
+            throw new Error(`Failed to fetch attachments for ${assignment.id}`);
+          }
+          const list = await response.json();
+          return {
+            assignmentId: assignment.id,
+            list
+          };
+        })
+      );
+
+      const nextAttachmentCounts = {};
+      const nextAttachmentLists = {};
+      attachmentSettled.forEach((result) => {
+        if (result.status === "fulfilled") {
+          const { assignmentId, list } = result.value;
+          nextAttachmentCounts[assignmentId] = list.length;
+          nextAttachmentLists[assignmentId] = list;
+        }
+      });
+
+      setAttachmentCounts(nextAttachmentCounts);
+      setAttachments((prev) => ({ ...prev, ...nextAttachmentLists }));
 
       if (countsRes.ok) {
         const counts = await countsRes.json();
@@ -175,6 +208,14 @@ function App() {
 
     return () => clearInterval(intervalId);
   }, [autoRefreshIntervalSeconds, refreshData]);
+
+  useEffect(() => {
+    return () => {
+      if (attachmentPreview?.objectUrl) {
+        window.URL.revokeObjectURL(attachmentPreview.objectUrl);
+      }
+    };
+  }, [attachmentPreview]);
 
   useEffect(() => {
     // Initialize unseen assignments so badges only represent comments
@@ -400,6 +441,7 @@ function App() {
         if (!response.ok) throw new Error("Failed to fetch attachments");
         const data = await response.json();
         setAttachments((prev) => ({ ...prev, [assignmentId]: data }));
+        setAttachmentCounts((prev) => ({ ...prev, [assignmentId]: data.length }));
       } catch (err) {
         setError(err.toString());
       } finally {
@@ -434,6 +476,10 @@ function App() {
         ...prev,
         [assignmentId]: [...(prev[assignmentId] || []), uploaded]
       }));
+      setAttachmentCounts((prev) => ({
+        ...prev,
+        [assignmentId]: (prev[assignmentId] ?? 0) + 1
+      }));
     } catch (err) {
       setError(err.toString());
     } finally {
@@ -463,6 +509,149 @@ function App() {
       window.URL.revokeObjectURL(url);
     } catch (err) {
       setError(err.toString());
+    }
+  };
+
+  const getAttachmentExtension = (fileName = "") => {
+    const parts = fileName.toLowerCase().split(".");
+    return parts.length > 1 ? parts.pop() : "";
+  };
+
+  const getPreviewKind = (fileName, contentType = "") => {
+    const ext = getAttachmentExtension(fileName);
+    const normalizedType = contentType.toLowerCase();
+
+    if (normalizedType.startsWith("image/")) return "image";
+    if (normalizedType === "application/pdf" || ext === "pdf") return "pdf";
+    if (
+      normalizedType.startsWith("text/") ||
+      ["txt", "md", "json", "xml", "csv", "log"].includes(ext)
+    ) {
+      return "text";
+    }
+    if (
+      ext === "docx" ||
+      normalizedType ===
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    ) {
+      return "docx";
+    }
+    return "unsupported";
+  };
+
+  const closeAttachmentPreview = () => {
+    setAttachmentPreview((prev) => {
+      if (prev?.objectUrl) {
+        window.URL.revokeObjectURL(prev.objectUrl);
+      }
+      return null;
+    });
+  };
+
+  const handlePreviewAttachment = async (assignmentId, attachment) => {
+    try {
+      setPreviewingAttachment(true);
+
+      const response = await fetch(
+        `${ASSIGNMENTS_API_URL}/${assignmentId}/attachments/${attachment.id}/download`
+      );
+
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || "Failed to preview attachment");
+      }
+
+      const blob = await response.blob();
+      const contentType =
+        response.headers.get("content-type") ||
+        attachment.contentType ||
+        blob.type ||
+        "";
+      const kind = getPreviewKind(attachment.fileName, contentType);
+
+      setAttachmentPreview((prev) => {
+        if (prev?.objectUrl) {
+          window.URL.revokeObjectURL(prev.objectUrl);
+        }
+        return prev;
+      });
+
+      if (kind === "image" || kind === "pdf") {
+        const objectUrl = window.URL.createObjectURL(blob);
+        setAttachmentPreview({
+          fileName: attachment.fileName,
+          kind,
+          contentType,
+          objectUrl,
+          text: "",
+          html: "",
+          error: null
+        });
+        return;
+      }
+
+      if (kind === "text") {
+        const text = await blob.text();
+        setAttachmentPreview({
+          fileName: attachment.fileName,
+          kind,
+          contentType,
+          objectUrl: "",
+          text,
+          html: "",
+          error: null
+        });
+        return;
+      }
+
+      if (kind === "docx") {
+        const arrayBuffer = await blob.arrayBuffer();
+
+        let mammothModule = null;
+        try {
+          mammothModule = await import("mammoth/mammoth.browser");
+        } catch {
+          mammothModule = await import("mammoth");
+        }
+
+        const mammothApi = mammothModule.default ?? mammothModule;
+        const result = await mammothApi.convertToHtml({ arrayBuffer });
+
+        setAttachmentPreview({
+          fileName: attachment.fileName,
+          kind,
+          contentType,
+          objectUrl: "",
+          text: "",
+          html: result.value || "",
+          error: null
+        });
+        return;
+      }
+
+      setAttachmentPreview({
+        fileName: attachment.fileName,
+        kind: "unsupported",
+        contentType,
+        objectUrl: "",
+        text: "",
+        html: "",
+        error:
+          "Preview is not available for this file type yet. Use Download instead."
+      });
+    } catch (err) {
+      setError(err.toString());
+      setAttachmentPreview({
+        fileName: attachment.fileName,
+        kind: "unsupported",
+        contentType: "",
+        objectUrl: "",
+        text: "",
+        html: "",
+        error: `Preview failed: ${err.toString()}`
+      });
+    } finally {
+      setPreviewingAttachment(false);
     }
   };
 
@@ -1281,7 +1470,10 @@ function App() {
                                 className="attachments-button"
                                 onClick={() => toggleAttachments(assignment.id)}
                               >
-                                📎 {attachments[assignment.id]?.length || 0}{" "}
+                                📎{" "}
+                                {attachmentCounts[assignment.id] ??
+                                  attachments[assignment.id]?.length ??
+                                  0}{" "}
                                 {openAttachments[assignment.id]
                                   ? "Hide"
                                   : "Attachments"}
@@ -1776,18 +1968,35 @@ function App() {
                                           key={attachment.id}
                                           className="attachment-item"
                                         >
-                                          <button
-                                            className="attachment-link"
-                                            onClick={() =>
-                                              handleDownloadAttachment(
-                                                assignment.id,
-                                                attachment
-                                              )
-                                            }
-                                            title={`Download ${attachment.fileName}`}
-                                          >
-                                            {attachment.fileName}
-                                          </button>
+                                          <div className="attachment-actions">
+                                            <button
+                                              className="attachment-link"
+                                              onClick={() =>
+                                                handleDownloadAttachment(
+                                                  assignment.id,
+                                                  attachment
+                                                )
+                                              }
+                                              title={`Download ${attachment.fileName}`}
+                                            >
+                                              {attachment.fileName}
+                                            </button>
+                                            <button
+                                              className="attachment-preview-button"
+                                              onClick={() =>
+                                                handlePreviewAttachment(
+                                                  assignment.id,
+                                                  attachment
+                                                )
+                                              }
+                                              disabled={previewingAttachment}
+                                              title={`Preview ${attachment.fileName}`}
+                                            >
+                                              {previewingAttachment
+                                                ? "Opening..."
+                                                : "Preview"}
+                                            </button>
+                                          </div>
                                           <span className="attachment-size">
                                             {Math.max(
                                               1,
@@ -2333,7 +2542,10 @@ function App() {
                             className="attachments-button"
                             onClick={() => toggleAttachments(assignment.id)}
                           >
-                            📎 {attachments[assignment.id]?.length || 0}{" "}
+                            📎{" "}
+                            {attachmentCounts[assignment.id] ??
+                              attachments[assignment.id]?.length ??
+                              0}{" "}
                             {openAttachments[assignment.id]
                               ? "Hide"
                               : "Attachments"}
@@ -2801,18 +3013,35 @@ function App() {
                                       key={attachment.id}
                                       className="attachment-item"
                                     >
-                                      <button
-                                        className="attachment-link"
-                                        onClick={() =>
-                                          handleDownloadAttachment(
-                                            assignment.id,
-                                            attachment
-                                          )
-                                        }
-                                        title={`Download ${attachment.fileName}`}
-                                      >
-                                        {attachment.fileName}
-                                      </button>
+                                      <div className="attachment-actions">
+                                        <button
+                                          className="attachment-link"
+                                          onClick={() =>
+                                            handleDownloadAttachment(
+                                              assignment.id,
+                                              attachment
+                                            )
+                                          }
+                                          title={`Download ${attachment.fileName}`}
+                                        >
+                                          {attachment.fileName}
+                                        </button>
+                                        <button
+                                          className="attachment-preview-button"
+                                          onClick={() =>
+                                            handlePreviewAttachment(
+                                              assignment.id,
+                                              attachment
+                                            )
+                                          }
+                                          disabled={previewingAttachment}
+                                          title={`Preview ${attachment.fileName}`}
+                                        >
+                                          {previewingAttachment
+                                            ? "Opening..."
+                                            : "Preview"}
+                                        </button>
+                                      </div>
                                       <span className="attachment-size">
                                         {Math.max(
                                           1,
@@ -3206,6 +3435,59 @@ function App() {
               );
             })()
           )}
+        </div>
+      )}
+      {attachmentPreview && (
+        <div className="attachment-preview-overlay" onClick={closeAttachmentPreview}>
+          <div
+            className="attachment-preview-modal"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="attachment-preview-header">
+              <h3 className="attachment-preview-title">
+                Preview: {attachmentPreview.fileName}
+              </h3>
+              <button
+                className="attachment-preview-close"
+                onClick={closeAttachmentPreview}
+              >
+                Close
+              </button>
+            </div>
+            <div className="attachment-preview-content">
+              {attachmentPreview.kind === "image" && (
+                <img
+                  src={attachmentPreview.objectUrl}
+                  alt={attachmentPreview.fileName}
+                  className="attachment-preview-image"
+                />
+              )}
+              {attachmentPreview.kind === "pdf" && (
+                <iframe
+                  src={attachmentPreview.objectUrl}
+                  title={attachmentPreview.fileName}
+                  className="attachment-preview-pdf"
+                />
+              )}
+              {attachmentPreview.kind === "text" && (
+                <pre className="attachment-preview-text">
+                  {attachmentPreview.text}
+                </pre>
+              )}
+              {attachmentPreview.kind === "docx" && (
+                <div
+                  className="attachment-preview-docx"
+                  dangerouslySetInnerHTML={{ __html: attachmentPreview.html }}
+                />
+              )}
+              {attachmentPreview.kind === "unsupported" && (
+                <div className="attachment-preview-unsupported">
+                  {attachmentPreview.error ||
+                    "Preview is not available for this file type."}
+                </div>
+              )}
+            </div>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- complete native `MFilesConnector` attachment operations (list, upload, download) including safe checkout/checkin and client-compatible download handling
- fix attachment count badges to preload and stay correct after refresh without opening each attachment panel
- add attachment preview support in the UI for images, PDF, text files, and Word `.docx` files (with graceful fallback for unsupported types)

## Test plan
- [x] Upload attachment in M-Files mode
- [x] List attachments in assignment cards after refresh
- [x] Download attachment in M-Files mode
- [x] Preview image attachment in modal
- [x] Preview PDF attachment in modal
- [x] Preview text attachment in modal
- [x] Preview `.docx` attachment in modal
- [x] Verify unsupported formats show fallback message and can still be downloaded
- [x] Run `dotnet test backend/Taskify.sln --no-restore`
- [x] Run `npm run build` in `client/`

## Notes
- legacy Word `.doc` preview is not included in-browser; users can still download and open locally.