### PR TITLE
feat(comments): newest-first ordering with persistent sort toggle

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -470,6 +470,8 @@
   margin-top: 1rem;
   padding-top: 1rem;
   border-top: 1px solid rgba(255, 255, 255, 0.1);
+  display: flex;
+  flex-direction: column;
 }
 
 .attachments-section {
@@ -721,15 +723,34 @@
   border-color: rgba(255, 255, 255, 0.3);
 }
 
+.comment-sort-toggle {
+  background: rgba(59, 130, 246, 0.18);
+  color: #bfdbfe;
+  border: 1px solid rgba(96, 165, 250, 0.45);
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.comment-sort-toggle:hover {
+  background: rgba(59, 130, 246, 0.28);
+  border-color: rgba(147, 197, 253, 0.65);
+}
+
 .comments-list {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
   max-height: 400px;
   overflow-y: auto;
-  margin-bottom: 1rem;
+  margin-top: 0.75rem;
+  margin-bottom: 0;
   padding-right: 0.5rem;
   align-items: stretch;
+  order: 3;
 }
 
 .comments-list::-webkit-scrollbar {
@@ -960,6 +981,7 @@
   display: flex;
   gap: 0.5rem;
   align-items: flex-start;
+  order: 2;
 }
 
 .comment-input {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -5,6 +5,7 @@ const ASSIGNMENTS_API_URL = "http://localhost:5000/api/assignments";
 const LAST_SEEN_COMMENT_COUNTS_KEY = "lastSeenCommentCounts";
 const SHOW_ONLY_UNREAD_ASSIGNMENTS_KEY = "showOnlyUnreadAssignments";
 const SORT_UNREAD_TO_TOP_KEY = "sortUnreadToTop";
+const COMMENT_SORT_NEWEST_FIRST_KEY = "commentSortNewestFirst";
 const AUTO_REFRESH_INTERVAL_SECONDS_KEY = "assignmentAutoRefreshSeconds";
 
 function App() {
@@ -65,6 +66,14 @@ function App() {
       return localStorage.getItem(SORT_UNREAD_TO_TOP_KEY) === "true";
     } catch {
       return false;
+    }
+  });
+  const [commentSortNewestFirst, setCommentSortNewestFirst] = useState(() => {
+    try {
+      const raw = localStorage.getItem(COMMENT_SORT_NEWEST_FIRST_KEY);
+      return raw === null ? true : raw === "true";
+    } catch {
+      return true;
     }
   });
   const [autoRefreshIntervalSeconds, setAutoRefreshIntervalSeconds] = useState(
@@ -187,6 +196,17 @@ function App() {
       // ignore storage write failures
     }
   }, [sortUnreadToTop]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        COMMENT_SORT_NEWEST_FIRST_KEY,
+        String(commentSortNewestFirst)
+      );
+    } catch {
+      // ignore storage write failures
+    }
+  }, [commentSortNewestFirst]);
 
   useEffect(() => {
     try {
@@ -1154,6 +1174,16 @@ function App() {
     return currentCount > seenCount;
   };
 
+  const sortCommentsByDate = (items) => {
+    const sorted = [...items].sort((a, b) => {
+      const dateA = new Date(a.createdDate).getTime();
+      const dateB = new Date(b.createdDate).getTime();
+      if (Number.isNaN(dateA) || Number.isNaN(dateB)) return 0;
+      return dateB - dateA;
+    });
+    return commentSortNewestFirst ? sorted : sorted.reverse();
+  };
+
   const formatCommentDate = (dateString) => {
     if (!dateString) return "";
     const date = new Date(dateString);
@@ -1592,6 +1622,23 @@ function App() {
                                       No Personal Note
                                     </option>
                                   </select>
+                                  <button
+                                    className="comment-sort-toggle"
+                                    onClick={() =>
+                                      setCommentSortNewestFirst(
+                                        !commentSortNewestFirst
+                                      )
+                                    }
+                                    title={
+                                      commentSortNewestFirst
+                                        ? "Switch to oldest comments first"
+                                        : "Switch to newest comments first"
+                                    }
+                                  >
+                                    {commentSortNewestFirst
+                                      ? "Sort: Newest first"
+                                      : "Sort: Oldest first"}
+                                  </button>
                                   {(commentFilters[assignment.id]?.user ||
                                     commentFilters[assignment.id]?.date ||
                                     commentFilters[assignment.id]?.flag ||
@@ -1716,6 +1763,9 @@ function App() {
                                             );
                                         }
                                       }
+
+                                      filteredComments =
+                                        sortCommentsByDate(filteredComments);
 
                                       return filteredComments.length > 0 ? (
                                         filteredComments.map((comment) => {
@@ -2658,6 +2708,23 @@ function App() {
                                   No Personal Note
                                 </option>
                               </select>
+                              <button
+                                className="comment-sort-toggle"
+                                onClick={() =>
+                                  setCommentSortNewestFirst(
+                                    !commentSortNewestFirst
+                                  )
+                                }
+                                title={
+                                  commentSortNewestFirst
+                                    ? "Switch to oldest comments first"
+                                    : "Switch to newest comments first"
+                                }
+                              >
+                                {commentSortNewestFirst
+                                  ? "Sort: Newest first"
+                                  : "Sort: Oldest first"}
+                              </button>
                               {(commentFilters[assignment.id]?.user ||
                                 commentFilters[assignment.id]?.date ||
                                 commentFilters[assignment.id]?.flag ||
@@ -2778,6 +2845,9 @@ function App() {
                                         );
                                     }
                                   }
+
+                                  filteredComments =
+                                    sortCommentsByDate(filteredComments);
 
                                   return filteredComments.length > 0 ? (
                                     filteredComments.map((comment) => {


### PR DESCRIPTION
## Summary
- default comment rendering to newest-first order and keep this preference persisted in localStorage
- add a `Sort: Newest first / Sort: Oldest first` toggle in comment controls for both Hot Zone and All Assignments cards
- improve usability by placing the comment composer above the comments list so users can add comments without extra scrolling

## Test plan
- [x] Open comments and verify latest comments appear first by default
- [x] Toggle sort order and verify comments switch between newest-first and oldest-first
- [x] Refresh page and verify sort preference persists
- [x] Verify filters (user/date/flag/note) still work with sorting applied
- [x] Verify comment composer appears above list and remains accessible
- [x] Run `npm run build` in `client/`

Closes #61

Made with [Cursor](https://cursor.com)