### PR TITLE
feat(comments): add local checklist subtasks per comment

### DIFF
--- a/backend/src/Taskify.Api/Program.cs
+++ b/backend/src/Taskify.Api/Program.cs
@@ -45,6 +45,7 @@ builder.Services.AddSingleton<SubtaskStore>();
 builder.Services.AddSingleton<SubtaskNoteStore>();
 builder.Services.AddSingleton<CommentNoteStore>();
 builder.Services.AddSingleton<CommentFlagStore>();
+builder.Services.AddSingleton<CommentSubtaskStore>();
 builder.Services.AddSingleton<AssignmentBoardStore>();
 builder.Services.AddSingleton<WorkingOnStore>();
 
@@ -58,6 +59,7 @@ builder.Services.AddScoped<CommentService>();
 builder.Services.AddScoped<SubtaskService>();
 builder.Services.AddScoped<CommentNoteService>();
 builder.Services.AddScoped<CommentFlagService>();
+builder.Services.AddScoped<CommentSubtaskService>();
 builder.Services.AddScoped<AssignmentBoardService>();
 builder.Services.AddScoped<WorkingOnService>();
 
@@ -259,6 +261,94 @@ app.MapPut("api/comments/{id:int}/flag", async (int id, CommentFlagService svc, 
     svc.SetCommentFlag(id, body.IsFlagged);
     return Results.Ok();
 });
+app.MapGet("api/comments/{id:int}/subtasks", (int id, CommentSubtaskService svc) =>
+{
+    try
+    {
+        var subtasks = svc.GetCommentSubtasks(id);
+        return Results.Ok(subtasks);
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ex.Message);
+    }
+});
+app.MapPost("api/comments/{id:int}/subtasks", async (int id, CommentSubtaskService svc, HttpRequest req) =>
+{
+    var body = await req.ReadFromJsonAsync<AddCommentSubtaskRequest>();
+    if (body == null || string.IsNullOrWhiteSpace(body.Title))
+        return Results.BadRequest("title is required");
+
+    try
+    {
+        var subtask = svc.AddCommentSubtask(id, body.Title, body.Order);
+        return Results.Ok(subtask);
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ex.Message);
+    }
+});
+app.MapPost("api/comments/subtasks/{id:int}/toggle", async (int id, CommentSubtaskService svc, HttpRequest req) =>
+{
+    var body = await req.ReadFromJsonAsync<ToggleCommentSubtaskRequest>();
+    if (body == null)
+        return Results.BadRequest("body required");
+
+    try
+    {
+        var ok = svc.ToggleCommentSubtaskCompletion(id, body.IsCompleted);
+        return ok ? Results.Ok() : Results.NotFound();
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ex.Message);
+    }
+});
+app.MapPut("api/comments/subtasks/{id:int}/title", async (int id, CommentSubtaskService svc, HttpRequest req) =>
+{
+    var body = await req.ReadFromJsonAsync<UpdateCommentSubtaskTitleRequest>();
+    if (body == null)
+        return Results.BadRequest("body required");
+
+    try
+    {
+        var ok = svc.UpdateCommentSubtaskTitle(id, body.Title);
+        return ok ? Results.Ok() : Results.NotFound();
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ex.Message);
+    }
+});
+app.MapPut("api/comments/{id:int}/subtasks/reorder", async (int id, CommentSubtaskService svc, HttpRequest req) =>
+{
+    var body = await req.ReadFromJsonAsync<ReorderCommentSubtasksRequest>();
+    if (body == null || body.SubtaskOrders == null || body.SubtaskOrders.Count == 0)
+        return Results.BadRequest("subtaskOrders required");
+
+    try
+    {
+        svc.ReorderCommentSubtasks(id, body.SubtaskOrders);
+        return Results.Ok();
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ex.Message);
+    }
+});
+app.MapDelete("api/comments/subtasks/{id:int}", (int id, CommentSubtaskService svc) =>
+{
+    try
+    {
+        var ok = svc.DeleteCommentSubtask(id);
+        return ok ? Results.Ok() : Results.NotFound();
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ex.Message);
+    }
+});
 
 // ─── Subtasks ───
 app.MapGet("api/assignments/{id:int}/subtasks", (int id, SubtaskService svc) =>
@@ -338,11 +428,15 @@ app.Run();
 
 public record AddCommentRequest(string Content);
 public record AddSubtaskRequest(string Title, int? Order);
+public record AddCommentSubtaskRequest(string Title, int? Order);
 public record ToggleSubtaskRequest(bool IsCompleted);
+public record ToggleCommentSubtaskRequest(bool IsCompleted);
 public record UpdateSubtaskTitleRequest(string Title);
+public record UpdateCommentSubtaskTitleRequest(string Title);
 public record UpdateNoteRequest(string? Note);
 public record UpdateCommentNoteRequest(string? Note);
 public record UpdateCommentFlagRequest(bool IsFlagged);
 public record ReorderSubtasksRequest(Dictionary<int, int> SubtaskOrders);
+public record ReorderCommentSubtasksRequest(Dictionary<int, int> SubtaskOrders);
 public record UpdateBoardColumnRequest(string? Column);
 public record UpdateWorkingOnRequest(bool IsWorkingOn);

--- a/backend/src/Taskify.Infrastructure/Storage/CommentSubtaskService.cs
+++ b/backend/src/Taskify.Infrastructure/Storage/CommentSubtaskService.cs
@@ -1,0 +1,73 @@
+namespace Taskify.Infrastructure.Storage;
+
+public class CommentSubtaskService
+{
+    private readonly CommentSubtaskStore _store;
+
+    public CommentSubtaskService(CommentSubtaskStore store)
+    {
+        _store = store;
+    }
+
+    public List<CommentSubtaskItem> GetCommentSubtasks(int commentId)
+    {
+        if (commentId <= 0)
+            throw new ArgumentException("Comment ID must be positive", nameof(commentId));
+
+        return _store.GetSubtasksForComment(commentId);
+    }
+
+    public CommentSubtaskItem AddCommentSubtask(int commentId, string title, int? order = null)
+    {
+        if (commentId <= 0)
+            throw new ArgumentException("Comment ID must be positive", nameof(commentId));
+        if (string.IsNullOrWhiteSpace(title))
+            throw new ArgumentException("Subtask title cannot be empty", nameof(title));
+
+        var trimmed = title.Trim();
+        if (trimmed.Length > 200)
+            throw new ArgumentException("Subtask title cannot exceed 200 characters", nameof(title));
+
+        return _store.AddSubtask(commentId, trimmed, order);
+    }
+
+    public bool ToggleCommentSubtaskCompletion(int subtaskId, bool isCompleted)
+    {
+        if (subtaskId <= 0)
+            throw new ArgumentException("Subtask ID must be positive", nameof(subtaskId));
+
+        return _store.SetCompletion(subtaskId, isCompleted);
+    }
+
+    public bool UpdateCommentSubtaskTitle(int subtaskId, string title)
+    {
+        if (subtaskId <= 0)
+            throw new ArgumentException("Subtask ID must be positive", nameof(subtaskId));
+        if (string.IsNullOrWhiteSpace(title))
+            throw new ArgumentException("Subtask title cannot be empty", nameof(title));
+
+        var trimmed = title.Trim();
+        if (trimmed.Length > 200)
+            throw new ArgumentException("Subtask title cannot exceed 200 characters", nameof(title));
+
+        return _store.SetTitle(subtaskId, trimmed);
+    }
+
+    public bool DeleteCommentSubtask(int subtaskId)
+    {
+        if (subtaskId <= 0)
+            throw new ArgumentException("Subtask ID must be positive", nameof(subtaskId));
+
+        return _store.DeleteSubtask(subtaskId);
+    }
+
+    public void ReorderCommentSubtasks(int commentId, Dictionary<int, int> subtaskIdToOrder)
+    {
+        if (commentId <= 0)
+            throw new ArgumentException("Comment ID must be positive", nameof(commentId));
+        if (subtaskIdToOrder == null || subtaskIdToOrder.Count == 0)
+            throw new ArgumentException("Subtask order mapping cannot be empty", nameof(subtaskIdToOrder));
+
+        _store.ReorderSubtasks(commentId, subtaskIdToOrder);
+    }
+}

--- a/backend/src/Taskify.Infrastructure/Storage/CommentSubtaskStore.cs
+++ b/backend/src/Taskify.Infrastructure/Storage/CommentSubtaskStore.cs
@@ -1,0 +1,225 @@
+using System.Text.Json;
+
+namespace Taskify.Infrastructure.Storage;
+
+public class CommentSubtaskStore
+{
+    private readonly string _storageFilePath;
+    private readonly object _syncRoot = new();
+    private CommentSubtaskStoreModel _model;
+
+    public CommentSubtaskStore(string storageDirectory = "storage")
+    {
+        if (!Path.IsPathRooted(storageDirectory))
+            storageDirectory = Path.Combine(AppContext.BaseDirectory, storageDirectory);
+
+        if (!Directory.Exists(storageDirectory))
+            Directory.CreateDirectory(storageDirectory);
+
+        _storageFilePath = Path.Combine(storageDirectory, "comment_subtasks.json");
+        _model = Load();
+    }
+
+    public List<CommentSubtaskItem> GetSubtasksForComment(int commentId)
+    {
+        lock (_syncRoot)
+        {
+            if (!_model.CommentIdToSubtasks.TryGetValue(commentId, out var items))
+                return new List<CommentSubtaskItem>();
+
+            return items
+                .OrderBy(i => i.Order)
+                .Select(i => new CommentSubtaskItem
+                {
+                    Id = i.Id,
+                    CommentId = commentId,
+                    Title = i.Title,
+                    IsCompleted = i.IsCompleted,
+                    Order = i.Order,
+                    CreatedDate = i.CreatedDate,
+                    CompletedDate = i.CompletedDate
+                })
+                .ToList();
+        }
+    }
+
+    public CommentSubtaskItem AddSubtask(int commentId, string title, int? order = null)
+    {
+        lock (_syncRoot)
+        {
+            var id = _model.NextId++;
+            var now = DateTime.UtcNow;
+            var list = _model.CommentIdToSubtasks.GetValueOrDefault(commentId) ?? new List<CommentSubtaskItemModel>();
+            var newOrder = order ?? (list.Count == 0 ? 0 : list.Max(i => i.Order) + 1);
+
+            var item = new CommentSubtaskItemModel
+            {
+                Id = id,
+                Title = title,
+                IsCompleted = false,
+                Order = newOrder,
+                CreatedDate = now
+            };
+
+            if (!_model.CommentIdToSubtasks.ContainsKey(commentId))
+                _model.CommentIdToSubtasks[commentId] = list;
+
+            list.Add(item);
+            Persist();
+
+            return new CommentSubtaskItem
+            {
+                Id = id,
+                CommentId = commentId,
+                Title = title,
+                IsCompleted = false,
+                Order = newOrder,
+                CreatedDate = now
+            };
+        }
+    }
+
+    public bool SetCompletion(int subtaskId, bool isCompleted)
+    {
+        lock (_syncRoot)
+        {
+            foreach (var kvp in _model.CommentIdToSubtasks)
+            {
+                var item = kvp.Value.FirstOrDefault(i => i.Id == subtaskId);
+                if (item == null)
+                    continue;
+
+                item.IsCompleted = isCompleted;
+                item.CompletedDate = isCompleted ? DateTime.UtcNow : null;
+                Persist();
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    public bool SetTitle(int subtaskId, string title)
+    {
+        lock (_syncRoot)
+        {
+            foreach (var kvp in _model.CommentIdToSubtasks)
+            {
+                var item = kvp.Value.FirstOrDefault(i => i.Id == subtaskId);
+                if (item == null)
+                    continue;
+
+                item.Title = title;
+                Persist();
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    public bool ReorderSubtasks(int commentId, Dictionary<int, int> subtaskIdToOrder)
+    {
+        lock (_syncRoot)
+        {
+            if (!_model.CommentIdToSubtasks.TryGetValue(commentId, out var items))
+                return false;
+
+            foreach (var kvp in subtaskIdToOrder)
+            {
+                var item = items.FirstOrDefault(i => i.Id == kvp.Key);
+                if (item != null)
+                    item.Order = kvp.Value;
+            }
+
+            Persist();
+            return true;
+        }
+    }
+
+    public bool DeleteSubtask(int subtaskId)
+    {
+        lock (_syncRoot)
+        {
+            foreach (var kvp in _model.CommentIdToSubtasks)
+            {
+                var item = kvp.Value.FirstOrDefault(i => i.Id == subtaskId);
+                if (item == null)
+                    continue;
+
+                kvp.Value.Remove(item);
+                Persist();
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    private CommentSubtaskStoreModel Load()
+    {
+        try
+        {
+            if (File.Exists(_storageFilePath))
+            {
+                var json = File.ReadAllText(_storageFilePath);
+                var loaded = JsonSerializer.Deserialize<CommentSubtaskStoreModel>(json);
+                if (loaded != null)
+                {
+                    loaded.CommentIdToSubtasks ??= new Dictionary<int, List<CommentSubtaskItemModel>>();
+                    return loaded;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Warning: Failed to load comment subtasks: {ex.Message}");
+        }
+
+        return new CommentSubtaskStoreModel
+        {
+            NextId = 1,
+            CommentIdToSubtasks = new Dictionary<int, List<CommentSubtaskItemModel>>()
+        };
+    }
+
+    private void Persist()
+    {
+        try
+        {
+            var json = JsonSerializer.Serialize(_model, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(_storageFilePath, json);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Warning: Failed to persist comment subtasks: {ex.Message}");
+        }
+    }
+
+    private class CommentSubtaskStoreModel
+    {
+        public int NextId { get; set; }
+        public Dictionary<int, List<CommentSubtaskItemModel>> CommentIdToSubtasks { get; set; } = new();
+    }
+
+    private class CommentSubtaskItemModel
+    {
+        public int Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public bool IsCompleted { get; set; }
+        public int Order { get; set; }
+        public DateTime CreatedDate { get; set; }
+        public DateTime? CompletedDate { get; set; }
+    }
+}
+
+public class CommentSubtaskItem
+{
+    public int Id { get; set; }
+    public int CommentId { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public bool IsCompleted { get; set; }
+    public int Order { get; set; }
+    public DateTime CreatedDate { get; set; }
+    public DateTime? CompletedDate { get; set; }
+}

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1005,6 +1005,111 @@
   white-space: pre-wrap;
 }
 
+.comment-subtasks {
+  margin-top: 0.6rem;
+  padding-top: 0.5rem;
+  border-top: 1px dashed rgba(255, 255, 255, 0.12);
+}
+
+.comment-subtasks-header {
+  margin-bottom: 0.45rem;
+}
+
+.comment-subtasks-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgba(255, 255, 255, 0.62);
+  font-weight: 600;
+}
+
+.comment-subtasks-loading {
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 0.8rem;
+}
+
+.comment-subtasks-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 0.45rem;
+}
+
+.comment-subtask-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.comment-subtask-checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.comment-subtask-title {
+  color: rgba(255, 255, 255, 0.84);
+  font-size: 0.84rem;
+  overflow-wrap: anywhere;
+}
+
+.comment-subtask-title.completed {
+  text-decoration: line-through;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.comment-subtask-delete {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.75);
+  border-radius: 6px;
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  font-size: 0.85rem;
+  flex-shrink: 0;
+}
+
+.comment-subtasks-add {
+  display: flex;
+  gap: 0.45rem;
+}
+
+.comment-subtask-input {
+  flex: 1;
+  min-width: 0;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  color: rgba(255, 255, 255, 0.9);
+  border-radius: 6px;
+  padding: 0.45rem 0.55rem;
+  font-size: 0.82rem;
+}
+
+.comment-subtask-add-button {
+  border: 1px solid rgba(16, 185, 129, 0.35);
+  background: rgba(16, 185, 129, 0.18);
+  color: #86efac;
+  border-radius: 6px;
+  padding: 0.4rem 0.65rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.comment-subtask-add-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .comments-loading,
 .comments-empty {
   text-align: center;

--- a/client/src/components/CommentsSection.jsx
+++ b/client/src/components/CommentsSection.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 function CommentsSection({
   assignmentId,
@@ -35,6 +35,9 @@ function CommentsSection({
 
   const allComments = commentsForAssignment || [];
   const activeFilter = filter || {};
+  const [commentSubtasks, setCommentSubtasks] = useState({});
+  const [loadingCommentSubtasks, setLoadingCommentSubtasks] = useState({});
+  const [newCommentSubtaskText, setNewCommentSubtaskText] = useState({});
 
   const loadCommentNoteIfNeeded = (commentId) => {
     if (commentNotes[commentId]) return;
@@ -50,6 +53,88 @@ function CommentsSection({
         }
       })
       .catch((err) => console.error("Error loading comment note:", err));
+  };
+
+  const loadCommentSubtasksIfNeeded = (commentId) => {
+    if (commentSubtasks[commentId] || loadingCommentSubtasks[commentId]) return;
+
+    setLoadingCommentSubtasks((prev) => ({ ...prev, [commentId]: true }));
+    fetch(`http://localhost:5000/api/comments/${commentId}/subtasks`)
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data) => {
+        setCommentSubtasks((prev) => ({ ...prev, [commentId]: data || [] }));
+      })
+      .catch((err) => console.error("Error loading comment subtasks:", err))
+      .finally(() => {
+        setLoadingCommentSubtasks((prev) => ({ ...prev, [commentId]: false }));
+      });
+  };
+
+  const handleAddCommentSubtask = async (commentId) => {
+    const title = (newCommentSubtaskText[commentId] || "").trim();
+    if (!title) return;
+
+    try {
+      const response = await fetch(
+        `http://localhost:5000/api/comments/${commentId}/subtasks`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title })
+        }
+      );
+
+      if (!response.ok) throw new Error("Failed to add comment subtask");
+
+      const created = await response.json();
+      setCommentSubtasks((prev) => ({
+        ...prev,
+        [commentId]: [...(prev[commentId] || []), created]
+      }));
+      setNewCommentSubtaskText((prev) => ({ ...prev, [commentId]: "" }));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleToggleCommentSubtask = async (commentId, subtaskId, isCompleted) => {
+    try {
+      const response = await fetch(
+        `http://localhost:5000/api/comments/subtasks/${subtaskId}/toggle`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ isCompleted })
+        }
+      );
+      if (!response.ok) throw new Error("Failed to toggle comment subtask");
+
+      setCommentSubtasks((prev) => ({
+        ...prev,
+        [commentId]: (prev[commentId] || []).map((item) =>
+          item.id === subtaskId ? { ...item, isCompleted } : item
+        )
+      }));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleDeleteCommentSubtask = async (commentId, subtaskId) => {
+    try {
+      const response = await fetch(
+        `http://localhost:5000/api/comments/subtasks/${subtaskId}`,
+        { method: "DELETE" }
+      );
+      if (!response.ok) throw new Error("Failed to delete comment subtask");
+
+      setCommentSubtasks((prev) => ({
+        ...prev,
+        [commentId]: (prev[commentId] || []).filter((item) => item.id !== subtaskId)
+      }));
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   let filteredComments = allComments;
@@ -274,6 +359,7 @@ function CommentsSection({
                         [comment.id]: !prev[comment.id]
                       }));
                       loadCommentNoteIfNeeded(comment.id);
+                      loadCommentSubtasksIfNeeded(comment.id);
                     }}
                     title={
                       commentNotes[comment.id]
@@ -341,6 +427,90 @@ function CommentsSection({
                     </span>
                   </div>
                 )}
+
+                <div className="comment-subtasks">
+                  <div className="comment-subtasks-header">
+                    <span className="comment-subtasks-label">Checklist</span>
+                  </div>
+
+                  {loadingCommentSubtasks[comment.id] ? (
+                    <div className="comment-subtasks-loading">Loading checklist...</div>
+                  ) : (
+                    <>
+                      {(commentSubtasks[comment.id] || []).length > 0 && (
+                        <div className="comment-subtasks-list">
+                          {(commentSubtasks[comment.id] || [])
+                            .slice()
+                            .sort((a, b) => a.order - b.order)
+                            .map((item) => (
+                              <div key={item.id} className="comment-subtask-item">
+                                <label className="comment-subtask-checkbox-label">
+                                  <input
+                                    type="checkbox"
+                                    checked={item.isCompleted}
+                                    onChange={(e) =>
+                                      handleToggleCommentSubtask(
+                                        comment.id,
+                                        item.id,
+                                        e.target.checked
+                                      )
+                                    }
+                                  />
+                                  <span
+                                    className={
+                                      item.isCompleted
+                                        ? "comment-subtask-title completed"
+                                        : "comment-subtask-title"
+                                    }
+                                  >
+                                    {item.title}
+                                  </span>
+                                </label>
+                                <button
+                                  className="comment-subtask-delete"
+                                  onClick={() =>
+                                    handleDeleteCommentSubtask(comment.id, item.id)
+                                  }
+                                  title="Delete checklist item"
+                                >
+                                  ✕
+                                </button>
+                              </div>
+                            ))}
+                        </div>
+                      )}
+
+                      <div className="comment-subtasks-add">
+                        <input
+                          className="comment-subtask-input"
+                          type="text"
+                          placeholder="Add checklist item..."
+                          value={newCommentSubtaskText[comment.id] || ""}
+                          onChange={(e) =>
+                            setNewCommentSubtaskText((prev) => ({
+                              ...prev,
+                              [comment.id]: e.target.value
+                            }))
+                          }
+                          onFocus={() => loadCommentSubtasksIfNeeded(comment.id)}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") {
+                              e.preventDefault();
+                              handleAddCommentSubtask(comment.id);
+                            }
+                          }}
+                        />
+                        <button
+                          className="comment-subtask-add-button"
+                          onClick={() => handleAddCommentSubtask(comment.id)}
+                          disabled={!newCommentSubtaskText[comment.id]?.trim()}
+                        >
+                          Add
+                        </button>
+                      </div>
+                    </>
+                  )}
+                </div>
               </div>
             );
           })


### PR DESCRIPTION
## Summary
- add backend local storage + service for comment checklist subtasks (private and non-vault)
- expose comment checklist APIs for list/add/toggle/update/reorder/delete
- add comment checklist UI inside each comment card, including add/toggle/delete and aligned remove icon styling

## Test plan
- [x] `dotnet build`
- [x] `npm run build`
- [x] add checklist item under a comment personal note
- [x] toggle checklist item complete/incomplete
- [x] delete checklist item and confirm UI updates immediately

Closes #39

Made with [Cursor](https://cursor.com)