### PR TITLE
fix(assignments): speed up active assignment loading and improve checklist UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Taskify is a productivity tool that extends M-Files assignment management. It pulls assignments from M-Files and layers on subtasks, personal notes, comment management, and a focused "Hot Zone" view, while also supporting a team oversight mode when broader visibility is needed.
 
+> MVP note: assignment lists currently focus on active work items (completed assignments are excluded from standard views for responsiveness).
+
 ## Overview
 
 - **Purpose:** Enhance task management for M-Files assignments by adding subtasks, personal notes, streamlined comment interaction, and optional team-level visibility.
@@ -79,7 +81,8 @@ Taskify
 │   ├── package.json                  # Node.js dependencies
 │   └── vite.config.js               # Vite configuration
 ├── docs
-│   └── adr/                          # Architecture Decision Records
+│   ├── adr/                          # Architecture Decision Records
+│   └── deployment/                   # Local production deployment guides
 └── .github/workflows/               # CI/CD workflows
 ```
 
@@ -193,6 +196,12 @@ ADRs are stored in [`docs/adr/`](docs/adr/) and document significant architectur
 
 Automated code quality and coverage checks via GitHub Actions. Requires `SONAR_TOKEN` and `GITHUB_TOKEN` secrets in repository settings.
 
+## Deployment
+
+For local production-style deployment (M-Files connector, published backend, and frontend preview), see:
+
+- [`docs/deployment/local-production.md`](docs/deployment/local-production.md)
+
 ## Roadmap
 
 - ✅ Pull assignments from M-Files and display in React frontend
@@ -203,11 +212,13 @@ Automated code quality and coverage checks via GitHub Actions. Requires `SONAR_T
 - ✅ Mark assignments as complete
 - ✅ "Hot Zone" pinning and assignment board
 - ✅ Connector abstraction (Mock + M-Files)
-- 🔜 Component refactoring (extract from monolithic App.jsx)
-- 🔜 New comment indicators
-- 🔜 Subtask editing and enhanced ordering
-- 🔜 Assignment attachments
-- 🔜 Team oversight view (all user assignments)
+- ✅ Component refactoring (extract from monolithic App.jsx)
+- ✅ New comment indicators and unread sorting/filtering
+- ✅ Subtask editing and enhanced ordering
+- ✅ Assignment attachments (list/upload/download/preview)
+- ✅ Team oversight view (all user assignments + assignee filter)
+- ✅ Local comment checklist subtasks (private, local-only)
+- 📋 Local quick tasks (not linked to assignments) with comments/checklists — planned ([#67](https://github.com/sekhubede/Taskify/issues/67))
 - 📋 Cloud-based subtasks, time tracking, AI features (future)
 
 ## License

--- a/backend/src/Taskify.Api/Program.cs
+++ b/backend/src/Taskify.Api/Program.cs
@@ -5,6 +5,7 @@ using Taskify.Application.Subtasks.Services;
 using Taskify.Domain.Interfaces;
 using Taskify.Infrastructure.Storage;
 using Taskify.Api.Infrastructure;
+using Microsoft.Extensions.Caching.Memory;
 
 
 var builder = WebApplication.CreateBuilder(args);
@@ -65,8 +66,11 @@ builder.Services.AddScoped<WorkingOnService>();
 
 // Verify connector on startup
 builder.Services.AddHostedService<ConnectorHostedService>();
+builder.Services.AddMemoryCache();
 
 var app = builder.Build();
+const string CommentCountsMineCacheKey = "comment-counts:mine";
+const string CommentCountsAllCacheKey = "comment-counts:all";
 
 app.UseCors();
 
@@ -201,16 +205,15 @@ app.MapGet("api/assignments/{id:int}/attachments/{attachmentId}/download", async
 // ─── Comments ───
 app.MapGet("api/assignments/{id:int}/comments", (int id, CommentService svc) =>
     Results.Ok(svc.GetAssignmentComments(id)));
-app.MapGet("api/assignments/comments/counts", (bool? all, AssignmentService assignmentSvc, CommentService commentSvc) =>
+app.MapGet("api/assignments/comments/counts", async (bool? all, AssignmentService assignmentSvc, CommentService commentSvc, IMemoryCache cache) =>
 {
+    var cacheKey = all == true ? CommentCountsAllCacheKey : CommentCountsMineCacheKey;
     try
     {
-        var assignments = all == true
-            ? assignmentSvc.GetAllAssignments()
-            : assignmentSvc.GetUserAssignments();
-        var counts = assignments.ToDictionary(
-            a => a.Id,
-            a => commentSvc.GetCommentCount(a.Id)
+        var counts = await GetOrCreateCommentCountsAsync(
+            cache,
+            cacheKey,
+            () => BuildCommentCounts(all == true, assignmentSvc, commentSvc)
         );
         return Results.Ok(counts);
     }
@@ -219,13 +222,37 @@ app.MapGet("api/assignments/comments/counts", (bool? all, AssignmentService assi
         return Results.BadRequest($"Error getting comment counts: {ex.Message}");
     }
 });
-app.MapPost("api/assignments/{id:int}/comments", async (int id, CommentService svc, HttpRequest req) =>
+app.MapGet("api/assignments/attachments/counts", async (bool? all, AssignmentService assignmentSvc, ITaskDataSource ds) =>
+{
+    try
+    {
+        var assignments = all == true
+            ? assignmentSvc.GetAllAssignments()
+            : assignmentSvc.GetUserAssignments();
+
+        var counts = new Dictionary<int, int>();
+        foreach (var assignment in assignments)
+        {
+            var attachments = await ds.GetAttachmentsForTaskAsync(assignment.Id.ToString());
+            counts[assignment.Id] = attachments.Count;
+        }
+
+        return Results.Ok(counts);
+    }
+    catch (Exception ex)
+    {
+        return Results.BadRequest($"Error getting attachment counts: {ex.Message}");
+    }
+});
+app.MapPost("api/assignments/{id:int}/comments", async (int id, CommentService svc, IMemoryCache cache, HttpRequest req) =>
 {
     var body = await req.ReadFromJsonAsync<AddCommentRequest>();
     if (body == null || string.IsNullOrWhiteSpace(body.Content))
         return Results.BadRequest("content is required");
 
     var c = svc.AddComment(id, body.Content.Trim());
+    cache.Remove(CommentCountsMineCacheKey);
+    cache.Remove(CommentCountsAllCacheKey);
     return Results.Ok(c);
 });
 app.MapGet("api/comments/{id:int}/note", (int id, CommentNoteService svc) =>
@@ -424,7 +451,69 @@ app.MapDelete("api/subtasks/{id:int}", (int id, SubtaskService svc) =>
     }
 });
 
+// Warm slow comment counts in the background so initial UI badges appear faster
+// after startup and auto-refresh has warm cache to read from.
+_ = Task.Run(async () =>
+{
+    await Task.Delay(TimeSpan.FromSeconds(1));
+    using var scope = app.Services.CreateScope();
+    var assignmentSvc = scope.ServiceProvider.GetRequiredService<AssignmentService>();
+    var commentSvc = scope.ServiceProvider.GetRequiredService<CommentService>();
+    var cache = scope.ServiceProvider.GetRequiredService<IMemoryCache>();
+    var logger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("CommentCountsWarmup");
+
+    try
+    {
+        await GetOrCreateCommentCountsAsync(
+            cache,
+            CommentCountsMineCacheKey,
+            () => BuildCommentCounts(includeAll: false, assignmentSvc, commentSvc)
+        );
+    }
+    catch (Exception ex)
+    {
+        logger.LogWarning(ex, "Failed to warm mine comment counts cache");
+    }
+
+    try
+    {
+        await GetOrCreateCommentCountsAsync(
+            cache,
+            CommentCountsAllCacheKey,
+            () => BuildCommentCounts(includeAll: true, assignmentSvc, commentSvc)
+        );
+    }
+    catch (Exception ex)
+    {
+        logger.LogWarning(ex, "Failed to warm all comment counts cache");
+    }
+});
+
 app.Run();
+
+static Dictionary<int, int> BuildCommentCounts(bool includeAll, AssignmentService assignmentSvc, CommentService commentSvc)
+{
+    var assignments = includeAll
+        ? assignmentSvc.GetAllAssignments()
+        : assignmentSvc.GetUserAssignments();
+    return assignments.ToDictionary(
+        a => a.Id,
+        a => commentSvc.GetCommentCount(a.Id)
+    );
+}
+
+static async Task<Dictionary<int, int>> GetOrCreateCommentCountsAsync(
+    IMemoryCache cache,
+    string cacheKey,
+    Func<Dictionary<int, int>> factory)
+{
+    var counts = await cache.GetOrCreateAsync(cacheKey, entry =>
+    {
+        entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(30);
+        return Task.FromResult(factory());
+    });
+    return counts ?? new Dictionary<int, int>();
+}
 
 public record AddCommentRequest(string Content);
 public record AddSubtaskRequest(string Title, int? Order);

--- a/backend/src/Taskify.Application/Assignments/Services/AssignmentService.cs
+++ b/backend/src/Taskify.Application/Assignments/Services/AssignmentService.cs
@@ -18,20 +18,22 @@ public class AssignmentService
     {
         try
         {
-            var tasks = _dataSource.GetAllTasksAsync().GetAwaiter().GetResult();
             var currentUserName = _dataSource.GetCurrentUserNameAsync().GetAwaiter().GetResult();
+            var userTasks = _dataSource.GetTasksByAssigneeAsync(currentUserName).GetAwaiter().GetResult();
+
+            if (userTasks.Count > 0)
+                return MapAndSortAssignments(userTasks.Where(IsActiveTask));
+
+            var tasks = _dataSource.GetAllTasksAsync().GetAwaiter().GetResult();
 
             var filtered = tasks
-                .Where(t => string.Equals(
-                    t.AssigneeName?.Trim(),
-                    currentUserName?.Trim(),
-                    StringComparison.OrdinalIgnoreCase))
+                .Where(t => IsCurrentUserAssignee(t.AssigneeName, currentUserName))
                 .ToList();
 
             // Fall back to all tasks if the source cannot provide a matching assignee name.
             // This keeps existing behavior for sources where user naming conventions differ.
             var tasksForView = filtered.Count > 0 ? filtered : tasks.ToList();
-            return MapAndSortAssignments(tasksForView);
+            return MapAndSortAssignments(tasksForView.Where(IsActiveTask));
         }
         catch (Exception ex)
         {
@@ -45,7 +47,7 @@ public class AssignmentService
         try
         {
             var tasks = _dataSource.GetAllTasksAsync().GetAwaiter().GetResult();
-            return MapAndSortAssignments(tasks);
+            return MapAndSortAssignments(tasks.Where(IsActiveTask));
         }
         catch (Exception ex)
         {
@@ -126,6 +128,21 @@ public class AssignmentService
             .ToList();
     }
 
+    private static bool IsCurrentUserAssignee(string? assigneeName, string? currentUserName)
+    {
+        if (string.IsNullOrWhiteSpace(currentUserName))
+            return false;
+
+        if (string.IsNullOrWhiteSpace(assigneeName))
+            return false;
+
+        var current = currentUserName.Trim();
+        return assigneeName
+            .Split(new[] { ',', ';', '|' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(name => name.Trim())
+            .Any(name => string.Equals(name, current, StringComparison.OrdinalIgnoreCase));
+    }
+
     private static AssignmentStatus MapStatus(TaskItemStatus status)
     {
         return status switch
@@ -137,6 +154,11 @@ public class AssignmentService
             TaskItemStatus.Overdue => AssignmentStatus.InProgress,
             _ => AssignmentStatus.NotStarted
         };
+    }
+
+    private static bool IsActiveTask(TaskDTO task)
+    {
+        return task.Status != TaskItemStatus.Completed;
     }
 }
 

--- a/backend/src/Taskify.Connectors/MFiles/MFilesConnector.cs
+++ b/backend/src/Taskify.Connectors/MFiles/MFilesConnector.cs
@@ -54,6 +54,17 @@ public class MFilesConnector : ITaskDataSource, IDisposable
             (int)MFBuiltInObjectType.MFBuiltInObjectTypeAssignment);
         searchConditions.Add(-1, objectTypeCondition);
 
+        // Active-only list by default to avoid pulling large historical completed datasets.
+        var completedCondition = new SearchCondition
+        {
+            ConditionType = MFConditionType.MFConditionTypeEqual
+        };
+        completedCondition.Expression.SetPropertyValueExpression(
+            (int)MFBuiltInPropertyDef.MFBuiltInPropertyDefCompleted,
+            MFParentChildBehavior.MFParentChildBehaviorNone);
+        completedCondition.TypedValue.SetValue(MFDataType.MFDatatypeBoolean, false);
+        searchConditions.Add(-1, completedCondition);
+
         var searchResults = vault.ObjectSearchOperations.SearchForObjectsByConditions(
             searchConditions,
             MFSearchFlags.MFSearchFlagNone,
@@ -83,10 +94,21 @@ public class MFilesConnector : ITaskDataSource, IDisposable
 
     public Task<IReadOnlyList<TaskDTO>> GetTasksByAssigneeAsync(string assigneeId)
     {
-        if (!int.TryParse(assigneeId, out var userId))
-            return Task.FromResult<IReadOnlyList<TaskDTO>>(new List<TaskDTO>());
-
         var vault = GetVault();
+        int userId;
+
+        if (!int.TryParse(assigneeId, out userId))
+        {
+            var currentName = GetCurrentUserNameAsync().GetAwaiter().GetResult();
+            if (string.IsNullOrWhiteSpace(currentName) ||
+                !string.Equals(currentName.Trim(), assigneeId?.Trim(), StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult<IReadOnlyList<TaskDTO>>(new List<TaskDTO>());
+            }
+
+            userId = vault.CurrentLoggedInUserID;
+        }
+
         var searchConditions = new SearchConditions();
 
         var deletedCondition = new SearchCondition
@@ -106,6 +128,16 @@ public class MFilesConnector : ITaskDataSource, IDisposable
             MFDataType.MFDatatypeLookup,
             (int)MFBuiltInObjectType.MFBuiltInObjectTypeAssignment);
         searchConditions.Add(-1, objectTypeCondition);
+
+        var completedCondition = new SearchCondition
+        {
+            ConditionType = MFConditionType.MFConditionTypeEqual
+        };
+        completedCondition.Expression.SetPropertyValueExpression(
+            (int)MFBuiltInPropertyDef.MFBuiltInPropertyDefCompleted,
+            MFParentChildBehavior.MFParentChildBehaviorNone);
+        completedCondition.TypedValue.SetValue(MFDataType.MFDatatypeBoolean, false);
+        searchConditions.Add(-1, completedCondition);
 
         var assignedToCondition = new SearchCondition
         {

--- a/backend/src/Taskify.Connectors/Mock/MockConnector.cs
+++ b/backend/src/Taskify.Connectors/Mock/MockConnector.cs
@@ -35,7 +35,13 @@ public class MockConnector : ITaskDataSource
     public async Task<IReadOnlyList<TaskDTO>> GetTasksByAssigneeAsync(string assigneeId)
     {
         await Task.Delay(200);
-        return _tasks.Where(t => t.AssigneeId == assigneeId).ToList().AsReadOnly();
+        var filtered = _tasks
+            .Where(t =>
+                string.Equals(t.AssigneeId, assigneeId, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(t.AssigneeName, assigneeId, StringComparison.OrdinalIgnoreCase))
+            .ToList()
+            .AsReadOnly();
+        return filtered;
     }
 
     public Task<bool> UpdateTaskStatusAsync(string taskId, TaskItemStatus newStatus)

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -184,6 +184,12 @@
   margin-left: 0.2rem;
 }
 
+.assignment-view-meta {
+  color: rgba(255, 255, 255, 0.65);
+  font-size: 0.76rem;
+  margin-left: 0.2rem;
+}
+
 .assignments-list {
   display: flex;
   flex-direction: column;
@@ -500,6 +506,12 @@
   font-weight: 700;
   line-height: 1.2;
   text-transform: uppercase;
+}
+
+.comments-checklist-summary {
+  color: rgba(134, 239, 172, 0.95);
+  font-weight: 600;
+  font-size: 0.72rem;
 }
 
 .comments-section {
@@ -1059,6 +1071,34 @@
 .comment-subtask-title.completed {
   text-decoration: line-through;
   color: rgba(255, 255, 255, 0.5);
+}
+
+.comment-subtask-title-input {
+  flex: 1;
+  min-width: 0;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  color: rgba(255, 255, 255, 0.92);
+  border-radius: 6px;
+  padding: 0.2rem 0.45rem;
+  font-size: 0.82rem;
+}
+
+.comment-subtask-edit {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.78);
+  border-radius: 6px;
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  font-size: 0.8rem;
+  flex-shrink: 0;
 }
 
 .comment-subtask-delete {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import "./App.css";
 import AssignmentCard from "./components/AssignmentCard";
 import WorkingOnSection from "./components/WorkingOnSection";
@@ -48,6 +48,7 @@ function App() {
   const [editingCommentNotes, setEditingCommentNotes] = useState({});
   const [commentNotes, setCommentNotes] = useState({});
   const [commentFlags, setCommentFlags] = useState({});
+  const [commentChecklistSummaries, setCommentChecklistSummaries] = useState({});
   const [draggedSubtaskId, setDraggedSubtaskId] = useState(null);
   const [dragOverSubtaskId, setDragOverSubtaskId] = useState(null);
   const [workingOn, setWorkingOn] = useState(new Set()); // assignmentIds that are marked as "working on"
@@ -99,17 +100,16 @@ function App() {
     }
   );
   const [lastRefreshedAt, setLastRefreshedAt] = useState(null);
+  const commentCountsRequestInFlightRef = useRef(false);
+  const attachmentCountsRequestInFlightRef = useRef(false);
 
   const refreshData = useCallback(async (isInitialLoad = false) => {
     try {
       const assignmentScopeQuery = showAllAssignments ? "?all=true" : "";
-      const [userRes, assignmentsRes, countsRes, workingOnRes] =
+      const [userRes, assignmentsRes, workingOnRes] =
         await Promise.all([
           fetch("http://localhost:5000/api/user/current"),
           fetch(`${ASSIGNMENTS_API_URL}${assignmentScopeQuery}`),
-          fetch(
-            `http://localhost:5000/api/assignments/comments/counts${assignmentScopeQuery}`
-          ),
           fetch("http://localhost:5000/api/assignments/working-on")
         ]);
 
@@ -122,39 +122,45 @@ function App() {
       const assignmentsData = await assignmentsRes.json();
       setAssignments(assignmentsData);
 
-      // Preload attachment counts so badges are correct without opening panels.
-      const attachmentSettled = await Promise.allSettled(
-        assignmentsData.map(async (assignment) => {
-          const response = await fetch(
-            `${ASSIGNMENTS_API_URL}/${assignment.id}/attachments`
-          );
-          if (!response.ok) {
-            throw new Error(`Failed to fetch attachments for ${assignment.id}`);
-          }
-          const list = await response.json();
-          return {
-            assignmentId: assignment.id,
-            list
-          };
-        })
-      );
+      // Keep assignment loading fast; hydrate comment counts asynchronously.
+      if (!commentCountsRequestInFlightRef.current) {
+        commentCountsRequestInFlightRef.current = true;
+        fetch(
+          `http://localhost:5000/api/assignments/comments/counts${assignmentScopeQuery}`
+        )
+          .then((res) => (res.ok ? res.json() : null))
+          .then((counts) => {
+            if (counts) {
+              setCommentCounts(counts);
+            }
+          })
+          .catch((err) =>
+            console.error("Error refreshing assignment comment counts:", err)
+          )
+          .finally(() => {
+            commentCountsRequestInFlightRef.current = false;
+          });
+      }
 
-      const nextAttachmentCounts = {};
-      const nextAttachmentLists = {};
-      attachmentSettled.forEach((result) => {
-        if (result.status === "fulfilled") {
-          const { assignmentId, list } = result.value;
-          nextAttachmentCounts[assignmentId] = list.length;
-          nextAttachmentLists[assignmentId] = list;
-        }
-      });
-
-      setAttachmentCounts(nextAttachmentCounts);
-      setAttachments((prev) => ({ ...prev, ...nextAttachmentLists }));
-
-      if (countsRes.ok) {
-        const counts = await countsRes.json();
-        setCommentCounts(counts);
+      // Load attachment counts in the background so badges are visible
+      // without opening every attachment panel.
+      if (!attachmentCountsRequestInFlightRef.current) {
+        attachmentCountsRequestInFlightRef.current = true;
+        fetch(
+          `http://localhost:5000/api/assignments/attachments/counts${assignmentScopeQuery}`
+        )
+          .then((res) => (res.ok ? res.json() : null))
+          .then((counts) => {
+            if (counts) {
+              setAttachmentCounts(counts);
+            }
+          })
+          .catch((err) =>
+            console.error("Error refreshing attachment counts:", err)
+          )
+          .finally(() => {
+            attachmentCountsRequestInFlightRef.current = false;
+          });
       }
 
       if (workingOnRes.ok) {
@@ -1256,6 +1262,48 @@ function App() {
     return colors[Math.abs(hash) % colors.length];
   };
 
+  const getAssigneeNames = (assignment) => {
+    const raw = assignment?.assignedTo?.trim();
+    if (!raw) return ["Unknown"];
+
+    const names = raw
+      .split(/[;,|]/)
+      .map((name) => name.trim())
+      .filter(Boolean);
+
+    return names.length > 0 ? names : ["Unknown"];
+  };
+
+  const availableAssignees = [
+    ...new Set(assignments.flatMap((assignment) => getAssigneeNames(assignment)))
+  ].sort((a, b) => a.localeCompare(b));
+
+  const normalizedSearchForMeta = assignmentSearch.trim().toLowerCase();
+  const assignmentsAfterSearch = normalizedSearchForMeta
+    ? assignments.filter((assignment) =>
+        [
+          assignment.title,
+          assignment.description,
+          getAssigneeNames(assignment).join(", "),
+          assignment.assigneeName
+        ]
+          .filter(Boolean)
+          .some((value) => value.toLowerCase().includes(normalizedSearchForMeta))
+      )
+    : assignments;
+  const assignmentsAfterAssignee =
+    showAllAssignments && assigneeFilter
+      ? assignmentsAfterSearch.filter((assignment) =>
+          getAssigneeNames(assignment).some((name) => name === assigneeFilter)
+        )
+      : assignmentsAfterSearch;
+  const assignmentsInCurrentView = showOnlyUnreadAssignments
+    ? assignmentsAfterAssignee.filter((assignment) => hasUnreadComments(assignment.id))
+    : assignmentsAfterAssignee;
+  const hotZoneCountInCurrentView = assignmentsInCurrentView.filter((a) =>
+    workingOn.has(a.id)
+  ).length;
+
   return (
     <div className="app">
       <header className="app-header">
@@ -1307,20 +1355,11 @@ function App() {
                   title="Filter assignments by assignee"
                 >
                   <option value="">Assignee: All</option>
-                  {[
-                    ...new Set(
-                      assignments.map((a) => {
-                        const name = a.assignedTo?.trim();
-                        return name && name.length > 0 ? name : "Unknown";
-                      })
-                    )
-                  ]
-                    .sort((a, b) => a.localeCompare(b))
-                    .map((assignee) => (
-                      <option key={assignee} value={assignee}>
-                        {assignee}
-                      </option>
-                    ))}
+                  {availableAssignees.map((assignee) => (
+                    <option key={assignee} value={assignee}>
+                      {assignee}
+                    </option>
+                  ))}
                 </select>
               )}
               <button
@@ -1368,6 +1407,11 @@ function App() {
                 ? new Date(lastRefreshedAt).toLocaleTimeString()
                 : "Not yet"}
             </div>
+            <div className="assignment-view-meta">
+              {showAllAssignments ? "Team" : "Mine"} assignments:{" "}
+              {assignmentsInCurrentView.length} total ({hotZoneCountInCurrentView}{" "}
+              in Hot Zone)
+            </div>
           </div>
           {assignments.length === 0 ? (
             <div className="empty-state">
@@ -1375,10 +1419,8 @@ function App() {
             </div>
           ) : (
             (() => {
-              const getAssigneeLabel = (assignment) => {
-                const name = assignment?.assignedTo?.trim();
-                return name && name.length > 0 ? name : "Unknown";
-              };
+              const getAssigneeLabel = (assignment) =>
+                getAssigneeNames(assignment).join(", ");
               const normalizedSearch = assignmentSearch.trim().toLowerCase();
               const filteredAssignments = normalizedSearch
                 ? assignments.filter((assignment) =>
@@ -1397,7 +1439,10 @@ function App() {
               const assigneeFilteredAssignments =
                 showAllAssignments && assigneeFilter
                   ? filteredAssignments.filter(
-                      (assignment) => getAssigneeLabel(assignment) === assigneeFilter
+                      (assignment) =>
+                        getAssigneeNames(assignment).some(
+                          (name) => name === assigneeFilter
+                        )
                     )
                   : filteredAssignments;
 
@@ -1489,6 +1534,8 @@ function App() {
                 handleToggleCommentFlag,
                 handleUpdateCommentNote,
                 handleDeleteCommentNote,
+                commentChecklistSummaries,
+                setCommentChecklistSummaries,
                 newCommentText,
                 setNewCommentText,
                 handleAddComment,

--- a/client/src/components/AssignmentCard.jsx
+++ b/client/src/components/AssignmentCard.jsx
@@ -41,6 +41,8 @@ function AssignmentCard({
   handleToggleCommentFlag,
   handleUpdateCommentNote,
   handleDeleteCommentNote,
+  commentChecklistSummaries,
+  setCommentChecklistSummaries,
   newCommentText,
   setNewCommentText,
   handleAddComment,
@@ -79,6 +81,10 @@ function AssignmentCard({
   const unread = hasUnreadComments(assignment.id);
   const assignmentSubtasks = subtasks[assignment.id] || assignment.subtasks || [];
   const completedCount = assignmentSubtasks.filter((s) => s.isCompleted).length;
+  const checklistSummary = commentChecklistSummaries?.[assignment.id] || {
+    total: 0,
+    completed: 0
+  };
   const assignedToLabel =
     assignment.assignedTo && assignment.assignedTo.trim().length > 0
       ? assignment.assignedTo
@@ -138,6 +144,12 @@ function AssignmentCard({
         >
           💬 {commentCounts[assignment.id] || 0}{" "}
           {openComments[assignment.id] ? "Hide" : "Comments"}
+          {checklistSummary.total > 0 && (
+            <span className="comments-checklist-summary">
+              {" "}
+              ☑ {checklistSummary.completed}/{checklistSummary.total}
+            </span>
+          )}
           {!openComments[assignment.id] && unread && (
             <span className="comments-new-indicator">New</span>
           )}
@@ -190,6 +202,12 @@ function AssignmentCard({
           handleToggleCommentFlag={handleToggleCommentFlag}
           handleUpdateCommentNote={handleUpdateCommentNote}
           handleDeleteCommentNote={handleDeleteCommentNote}
+          onChecklistSummaryChange={(summary) =>
+            setCommentChecklistSummaries((prev) => ({
+              ...prev,
+              [assignment.id]: summary
+            }))
+          }
           newCommentText={newCommentText[assignment.id]}
           setNewCommentText={setNewCommentText}
           handleAddComment={handleAddComment}

--- a/client/src/components/CommentsSection.jsx
+++ b/client/src/components/CommentsSection.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 function CommentsSection({
   assignmentId,
@@ -20,6 +20,7 @@ function CommentsSection({
   handleToggleCommentFlag,
   handleUpdateCommentNote,
   handleDeleteCommentNote,
+  onChecklistSummaryChange,
   newCommentText,
   setNewCommentText,
   handleAddComment
@@ -38,6 +39,18 @@ function CommentsSection({
   const [commentSubtasks, setCommentSubtasks] = useState({});
   const [loadingCommentSubtasks, setLoadingCommentSubtasks] = useState({});
   const [newCommentSubtaskText, setNewCommentSubtaskText] = useState({});
+  const [editingChecklistTitles, setEditingChecklistTitles] = useState({});
+  const [checklistTitleDrafts, setChecklistTitleDrafts] = useState({});
+  const [draggedChecklistItem, setDraggedChecklistItem] = useState(null);
+  const [dragOverChecklistItem, setDragOverChecklistItem] = useState(null);
+
+  const summarizeChecklist = (subtaskMap) => {
+    const all = allComments.flatMap((comment) => subtaskMap[comment.id] || []);
+    return {
+      total: all.length,
+      completed: all.filter((item) => item.isCompleted).length
+    };
+  };
 
   const loadCommentNoteIfNeeded = (commentId) => {
     if (commentNotes[commentId]) return;
@@ -70,6 +83,49 @@ function CommentsSection({
       });
   };
 
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadAllChecklistData = async () => {
+      if (!allComments.length) {
+        setCommentSubtasks({});
+        onChecklistSummaryChange?.({ total: 0, completed: 0 });
+        return;
+      }
+
+      try {
+        const entries = await Promise.all(
+          allComments.map(async (comment) => {
+            const res = await fetch(
+              `http://localhost:5000/api/comments/${comment.id}/subtasks`
+            );
+            if (!res.ok) return [comment.id, []];
+            const items = await res.json();
+            return [comment.id, items || []];
+          })
+        );
+
+        if (cancelled) return;
+
+        const next = {};
+        entries.forEach(([commentId, items]) => {
+          next[commentId] = items;
+        });
+        setCommentSubtasks(next);
+        onChecklistSummaryChange?.(summarizeChecklist(next));
+      } catch (err) {
+        if (!cancelled) {
+          console.error("Error loading comment checklist data:", err);
+        }
+      }
+    };
+
+    loadAllChecklistData();
+    return () => {
+      cancelled = true;
+    };
+  }, [assignmentId, commentsForAssignment]);
+
   const handleAddCommentSubtask = async (commentId) => {
     const title = (newCommentSubtaskText[commentId] || "").trim();
     if (!title) return;
@@ -87,10 +143,14 @@ function CommentsSection({
       if (!response.ok) throw new Error("Failed to add comment subtask");
 
       const created = await response.json();
-      setCommentSubtasks((prev) => ({
-        ...prev,
-        [commentId]: [...(prev[commentId] || []), created]
-      }));
+      setCommentSubtasks((prev) => {
+        const next = {
+          ...prev,
+          [commentId]: [...(prev[commentId] || []), created]
+        };
+        onChecklistSummaryChange?.(summarizeChecklist(next));
+        return next;
+      });
       setNewCommentSubtaskText((prev) => ({ ...prev, [commentId]: "" }));
     } catch (err) {
       console.error(err);
@@ -109,12 +169,16 @@ function CommentsSection({
       );
       if (!response.ok) throw new Error("Failed to toggle comment subtask");
 
-      setCommentSubtasks((prev) => ({
-        ...prev,
-        [commentId]: (prev[commentId] || []).map((item) =>
-          item.id === subtaskId ? { ...item, isCompleted } : item
-        )
-      }));
+      setCommentSubtasks((prev) => {
+        const next = {
+          ...prev,
+          [commentId]: (prev[commentId] || []).map((item) =>
+            item.id === subtaskId ? { ...item, isCompleted } : item
+          )
+        };
+        onChecklistSummaryChange?.(summarizeChecklist(next));
+        return next;
+      });
     } catch (err) {
       console.error(err);
     }
@@ -128,12 +192,119 @@ function CommentsSection({
       );
       if (!response.ok) throw new Error("Failed to delete comment subtask");
 
-      setCommentSubtasks((prev) => ({
-        ...prev,
-        [commentId]: (prev[commentId] || []).filter((item) => item.id !== subtaskId)
-      }));
+      setCommentSubtasks((prev) => {
+        const next = {
+          ...prev,
+          [commentId]: (prev[commentId] || []).filter(
+            (item) => item.id !== subtaskId
+          )
+        };
+        onChecklistSummaryChange?.(summarizeChecklist(next));
+        return next;
+      });
     } catch (err) {
       console.error(err);
+    }
+  };
+
+  const handleStartChecklistEdit = (subtaskId, currentTitle) => {
+    setEditingChecklistTitles((prev) => ({ ...prev, [subtaskId]: true }));
+    setChecklistTitleDrafts((prev) => ({
+      ...prev,
+      [subtaskId]: currentTitle || ""
+    }));
+  };
+
+  const handleCancelChecklistEdit = (subtaskId) => {
+    setEditingChecklistTitles((prev) => ({ ...prev, [subtaskId]: false }));
+    setChecklistTitleDrafts((prev) => {
+      const next = { ...prev };
+      delete next[subtaskId];
+      return next;
+    });
+  };
+
+  const handleSaveChecklistEdit = async (commentId, subtaskId) => {
+    const title = (checklistTitleDrafts[subtaskId] || "").trim();
+    if (!title) return;
+
+    try {
+      const response = await fetch(
+        `http://localhost:5000/api/comments/subtasks/${subtaskId}/title`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title })
+        }
+      );
+      if (!response.ok) throw new Error("Failed to update checklist item");
+
+      setCommentSubtasks((prev) => {
+        const next = {
+          ...prev,
+          [commentId]: (prev[commentId] || []).map((item) =>
+            item.id === subtaskId ? { ...item, title } : item
+          )
+        };
+        onChecklistSummaryChange?.(summarizeChecklist(next));
+        return next;
+      });
+      handleCancelChecklistEdit(subtaskId);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleChecklistDragStart = (commentId, subtaskId) => {
+    setDraggedChecklistItem({ commentId, subtaskId });
+  };
+
+  const handleChecklistDragOver = (commentId, subtaskId) => {
+    if (!draggedChecklistItem) return;
+    if (draggedChecklistItem.commentId !== commentId) return;
+    if (draggedChecklistItem.subtaskId === subtaskId) return;
+    setDragOverChecklistItem({ commentId, subtaskId });
+  };
+
+  const handleChecklistDrop = async (commentId, targetSubtaskId) => {
+    if (!draggedChecklistItem) return;
+    if (draggedChecklistItem.commentId !== commentId) return;
+
+    const sourceSubtaskId = draggedChecklistItem.subtaskId;
+    const items = [...(commentSubtasks[commentId] || [])].sort(
+      (a, b) => a.order - b.order
+    );
+    const sourceIndex = items.findIndex((i) => i.id === sourceSubtaskId);
+    const targetIndex = items.findIndex((i) => i.id === targetSubtaskId);
+    if (sourceIndex < 0 || targetIndex < 0) return;
+
+    const reordered = [...items];
+    const [moved] = reordered.splice(sourceIndex, 1);
+    reordered.splice(targetIndex, 0, moved);
+
+    const normalized = reordered.map((item, index) => ({ ...item, order: index }));
+    const orderPayload = {};
+    normalized.forEach((item, index) => {
+      orderPayload[item.id] = index;
+    });
+
+    setCommentSubtasks((prev) => {
+      const next = { ...prev, [commentId]: normalized };
+      onChecklistSummaryChange?.(summarizeChecklist(next));
+      return next;
+    });
+
+    try {
+      await fetch(`http://localhost:5000/api/comments/${commentId}/subtasks/reorder`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ subtaskOrders: orderPayload })
+      });
+    } catch (err) {
+      console.error("Error reordering checklist items:", err);
+    } finally {
+      setDraggedChecklistItem(null);
+      setDragOverChecklistItem(null);
     }
   };
 
@@ -191,6 +362,18 @@ function CommentsSection({
       filteredComments = filteredComments.filter((c) => commentNotes[c.id]);
     } else if (activeFilter.note === "no-note") {
       filteredComments = filteredComments.filter((c) => !commentNotes[c.id]);
+    }
+  }
+
+  if (activeFilter.checklist) {
+    if (activeFilter.checklist === "has-checklist") {
+      filteredComments = filteredComments.filter(
+        (c) => (commentSubtasks[c.id] || []).length > 0
+      );
+    } else if (activeFilter.checklist === "no-checklist") {
+      filteredComments = filteredComments.filter(
+        (c) => (commentSubtasks[c.id] || []).length === 0
+      );
     }
   }
 
@@ -273,6 +456,23 @@ function CommentsSection({
           <option value="has-note">Has Personal Note</option>
           <option value="no-note">No Personal Note</option>
         </select>
+        <select
+          className="comment-filter-select"
+          value={activeFilter.checklist || ""}
+          onChange={(e) =>
+            setCommentFilters((prev) => ({
+              ...prev,
+              [assignmentId]: {
+                ...prev[assignmentId],
+                checklist: e.target.value || null
+              }
+            }))
+          }
+        >
+          <option value="">All Checklists</option>
+          <option value="has-checklist">Has Checklist</option>
+          <option value="no-checklist">No Checklist</option>
+        </select>
         <button
           className="comment-sort-toggle"
           onClick={() => setCommentSortNewestFirst(!commentSortNewestFirst)}
@@ -287,7 +487,8 @@ function CommentsSection({
         {(activeFilter.user ||
           activeFilter.date ||
           activeFilter.flag ||
-          activeFilter.note) && (
+          activeFilter.note ||
+          activeFilter.checklist) && (
           <button
             className="comment-filter-clear"
             onClick={() =>
@@ -297,7 +498,8 @@ function CommentsSection({
                   user: null,
                   date: null,
                   flag: null,
-                  note: null
+                  note: null,
+                  checklist: null
                 }
               }))
             }
@@ -444,7 +646,21 @@ function CommentsSection({
                             .sort((a, b) => a.order - b.order)
                             .map((item) => (
                               <div key={item.id} className="comment-subtask-item">
-                                <label className="comment-subtask-checkbox-label">
+                                <label
+                                  className="comment-subtask-checkbox-label"
+                                  draggable
+                                  onDragStart={() =>
+                                    handleChecklistDragStart(comment.id, item.id)
+                                  }
+                                  onDragOver={(e) => {
+                                    e.preventDefault();
+                                    handleChecklistDragOver(comment.id, item.id);
+                                  }}
+                                  onDrop={(e) => {
+                                    e.preventDefault();
+                                    handleChecklistDrop(comment.id, item.id);
+                                  }}
+                                >
                                   <input
                                     type="checkbox"
                                     checked={item.isCompleted}
@@ -456,16 +672,70 @@ function CommentsSection({
                                       )
                                     }
                                   />
-                                  <span
-                                    className={
-                                      item.isCompleted
-                                        ? "comment-subtask-title completed"
-                                        : "comment-subtask-title"
-                                    }
-                                  >
-                                    {item.title}
-                                  </span>
+                                  {editingChecklistTitles[item.id] ? (
+                                    <input
+                                      className="comment-subtask-title-input"
+                                      type="text"
+                                      value={checklistTitleDrafts[item.id] || ""}
+                                      onChange={(e) =>
+                                        setChecklistTitleDrafts((prev) => ({
+                                          ...prev,
+                                          [item.id]: e.target.value
+                                        }))
+                                      }
+                                      onKeyDown={(e) => {
+                                        if (e.key === "Enter") {
+                                          e.preventDefault();
+                                          handleSaveChecklistEdit(comment.id, item.id);
+                                        } else if (e.key === "Escape") {
+                                          e.preventDefault();
+                                          handleCancelChecklistEdit(item.id);
+                                        }
+                                      }}
+                                      autoFocus
+                                    />
+                                  ) : (
+                                    <span
+                                      className={
+                                        item.isCompleted
+                                          ? "comment-subtask-title completed"
+                                          : "comment-subtask-title"
+                                      }
+                                    >
+                                      {item.title}
+                                    </span>
+                                  )}
                                 </label>
+                                {editingChecklistTitles[item.id] ? (
+                                  <>
+                                    <button
+                                      className="comment-subtask-edit"
+                                      onClick={() =>
+                                        handleSaveChecklistEdit(comment.id, item.id)
+                                      }
+                                      title="Save checklist item"
+                                    >
+                                      ✓
+                                    </button>
+                                    <button
+                                      className="comment-subtask-edit"
+                                      onClick={() => handleCancelChecklistEdit(item.id)}
+                                      title="Cancel edit"
+                                    >
+                                      ↺
+                                    </button>
+                                  </>
+                                ) : (
+                                  <button
+                                    className="comment-subtask-edit"
+                                    onClick={() =>
+                                      handleStartChecklistEdit(item.id, item.title)
+                                    }
+                                    title="Edit checklist item"
+                                  >
+                                    ✎
+                                  </button>
+                                )}
                                 <button
                                   className="comment-subtask-delete"
                                   onClick={() =>


### PR DESCRIPTION
## Summary
- prioritize active assignment responsiveness by loading assignment cards first, then hydrating comment and attachment counts asynchronously
- add cache-backed + warmup handling for assignment comment counts and keep views focused on active assignments only
- enhance comment checklist UX with inline edit, drag-and-drop reordering, and README updates reflecting current roadmap/deployment docs

## Test plan
- [x] `dotnet build` (backend)
- [x] `npm run build` (client)
- [x] Load `Mine` and verify assignments render quickly while badges hydrate shortly after
- [x] Switch to `Team` and verify counts continue to hydrate without blocking assignment rendering
- [x] Add/edit/reorder/delete comment checklist items and verify persistence after close/reopen
- [x] Validate attachments/comments count badges populate without opening every panel

Made with [Cursor](https://cursor.com)