### PR TITLE
feat(quick-tasks): add local quick tasks and restore deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Taskify is a productivity tool that extends M-Files assignment management. It pu
   - Pull assignments and comments from M-Files
   - Add, manage, reorder, and delete subtasks per assignment
   - Add vault comments (synced to M-Files) and personal notes (local only)
+  - Create local quick tasks with local comments and checklist items
   - Pin assignments to a "Hot Zone" section for focused work
   - Toggle between "My assignments" and "Team assignments"
   - Filter team view by assignee
@@ -56,6 +57,7 @@ Single-page application that displays assignments from the API and provides inte
 | Personal notes | Browser localStorage | No — machine-specific |
 | Comment flags | Browser localStorage | No — machine-specific |
 | Working-on flags | Backend API (local file) | No — machine-specific |
+| Quick tasks, quick task comments/checklists | Backend API (local file) | No — machine-specific |
 
 > See [ADR-002](docs/adr/002-local-storage-for-subtasks-and-notes.md) and [ADR-003](docs/adr/003-comment-system-migration-to-connectors.md) for storage decisions.
 
@@ -218,7 +220,7 @@ For local production-style deployment (M-Files connector, published backend, and
 - ✅ Assignment attachments (list/upload/download/preview)
 - ✅ Team oversight view (all user assignments + assignee filter)
 - ✅ Local comment checklist subtasks (private, local-only)
-- 📋 Local quick tasks (not linked to assignments) with comments/checklists — planned ([#67](https://github.com/sekhubede/Taskify/issues/67))
+- ✅ Local quick tasks (not linked to assignments) with comments/checklists ([#67](https://github.com/sekhubede/Taskify/issues/67))
 - 📋 Cloud-based subtasks, time tracking, AI features (future)
 
 ## License

--- a/backend/src/Taskify.Api/Program.cs
+++ b/backend/src/Taskify.Api/Program.cs
@@ -543,6 +543,34 @@ app.MapPost("api/quick-tasks/{id:int}/comments", async (int id, QuickTaskService
         return Results.BadRequest(ex.Message);
     }
 });
+app.MapPut("api/quick-task-comments/{id:int}/content", async (int id, QuickTaskService svc, HttpRequest req) =>
+{
+    var body = await req.ReadFromJsonAsync<UpdateQuickTaskCommentContentRequest>();
+    if (body == null)
+        return Results.BadRequest("body required");
+
+    try
+    {
+        var ok = svc.UpdateTaskComment(id, body.Content);
+        return ok ? Results.Ok() : Results.NotFound();
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ex.Message);
+    }
+});
+app.MapDelete("api/quick-task-comments/{id:int}", (int id, QuickTaskService svc) =>
+{
+    try
+    {
+        var ok = svc.DeleteTaskComment(id);
+        return ok ? Results.Ok() : Results.NotFound();
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ex.Message);
+    }
+});
 app.MapGet("api/quick-tasks/{id:int}/checklist", (int id, QuickTaskService svc) =>
 {
     try
@@ -713,6 +741,7 @@ public record AddQuickTaskRequest(string Title);
 public record UpdateQuickTaskTitleRequest(string Title);
 public record ToggleQuickTaskRequest(bool IsCompleted);
 public record AddQuickTaskCommentRequest(string Content);
+public record UpdateQuickTaskCommentContentRequest(string Content);
 public record AddQuickTaskChecklistItemRequest(string Title, int? Order);
 public record ToggleQuickTaskChecklistItemRequest(bool IsCompleted);
 public record UpdateQuickTaskChecklistItemTitleRequest(string Title);

--- a/backend/src/Taskify.Api/Program.cs
+++ b/backend/src/Taskify.Api/Program.cs
@@ -47,6 +47,7 @@ builder.Services.AddSingleton<SubtaskNoteStore>();
 builder.Services.AddSingleton<CommentNoteStore>();
 builder.Services.AddSingleton<CommentFlagStore>();
 builder.Services.AddSingleton<CommentSubtaskStore>();
+builder.Services.AddSingleton<QuickTaskStore>();
 builder.Services.AddSingleton<AssignmentBoardStore>();
 builder.Services.AddSingleton<WorkingOnStore>();
 
@@ -61,6 +62,7 @@ builder.Services.AddScoped<SubtaskService>();
 builder.Services.AddScoped<CommentNoteService>();
 builder.Services.AddScoped<CommentFlagService>();
 builder.Services.AddScoped<CommentSubtaskService>();
+builder.Services.AddScoped<QuickTaskService>();
 builder.Services.AddScoped<AssignmentBoardService>();
 builder.Services.AddScoped<WorkingOnService>();
 
@@ -451,6 +453,184 @@ app.MapDelete("api/subtasks/{id:int}", (int id, SubtaskService svc) =>
     }
 });
 
+// ─── Quick Tasks (local-only) ───
+app.MapGet("api/quick-tasks", (QuickTaskService svc) =>
+    Results.Ok(svc.GetTasks()));
+app.MapPost("api/quick-tasks", async (QuickTaskService svc, HttpRequest req) =>
+{
+    var body = await req.ReadFromJsonAsync<AddQuickTaskRequest>();
+    if (body == null || string.IsNullOrWhiteSpace(body.Title))
+        return Results.BadRequest("title is required");
+
+    try
+    {
+        var task = svc.AddTask(body.Title);
+        return Results.Ok(task);
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ex.Message);
+    }
+});
+app.MapPut("api/quick-tasks/{id:int}/title", async (int id, QuickTaskService svc, HttpRequest req) =>
+{
+    var body = await req.ReadFromJsonAsync<UpdateQuickTaskTitleRequest>();
+    if (body == null)
+        return Results.BadRequest("body required");
+
+    try
+    {
+        var ok = svc.UpdateTaskTitle(id, body.Title);
+        return ok ? Results.Ok() : Results.NotFound();
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ex.Message);
+    }
+});
+app.MapPost("api/quick-tasks/{id:int}/toggle", async (int id, QuickTaskService svc, HttpRequest req) =>
+{
+    var body = await req.ReadFromJsonAsync<ToggleQuickTaskRequest>();
+    if (body == null)
+        return Results.BadRequest("body required");
+
+    try
+    {
+        var ok = svc.ToggleTaskCompletion(id, body.IsCompleted);
+        return ok ? Results.Ok() : Results.NotFound();
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ex.Message);
+    }
+});
+app.MapDelete("api/quick-tasks/{id:int}", (int id, QuickTaskService svc) =>
+{
+    try
+    {
+        var ok = svc.DeleteTask(id);
+        return ok ? Results.Ok() : Results.NotFound();
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ex.Message);
+    }
+});
+app.MapGet("api/quick-tasks/{id:int}/comments", (int id, QuickTaskService svc) =>
+{
+    try
+    {
+        return Results.Ok(svc.GetTaskComments(id));
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ex.Message);
+    }
+});
+app.MapPost("api/quick-tasks/{id:int}/comments", async (int id, QuickTaskService svc, HttpRequest req) =>
+{
+    var body = await req.ReadFromJsonAsync<AddQuickTaskCommentRequest>();
+    if (body == null || string.IsNullOrWhiteSpace(body.Content))
+        return Results.BadRequest("content is required");
+
+    try
+    {
+        var comment = svc.AddTaskComment(id, body.Content);
+        return Results.Ok(comment);
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ex.Message);
+    }
+});
+app.MapGet("api/quick-tasks/{id:int}/checklist", (int id, QuickTaskService svc) =>
+{
+    try
+    {
+        return Results.Ok(svc.GetTaskChecklist(id));
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ex.Message);
+    }
+});
+app.MapPost("api/quick-tasks/{id:int}/checklist", async (int id, QuickTaskService svc, HttpRequest req) =>
+{
+    var body = await req.ReadFromJsonAsync<AddQuickTaskChecklistItemRequest>();
+    if (body == null || string.IsNullOrWhiteSpace(body.Title))
+        return Results.BadRequest("title is required");
+
+    try
+    {
+        var item = svc.AddChecklistItem(id, body.Title, body.Order);
+        return Results.Ok(item);
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ex.Message);
+    }
+});
+app.MapPost("api/quick-task-checklist/{id:int}/toggle", async (int id, QuickTaskService svc, HttpRequest req) =>
+{
+    var body = await req.ReadFromJsonAsync<ToggleQuickTaskChecklistItemRequest>();
+    if (body == null)
+        return Results.BadRequest("body required");
+
+    try
+    {
+        var ok = svc.ToggleChecklistItem(id, body.IsCompleted);
+        return ok ? Results.Ok() : Results.NotFound();
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ex.Message);
+    }
+});
+app.MapPut("api/quick-task-checklist/{id:int}/title", async (int id, QuickTaskService svc, HttpRequest req) =>
+{
+    var body = await req.ReadFromJsonAsync<UpdateQuickTaskChecklistItemTitleRequest>();
+    if (body == null)
+        return Results.BadRequest("body required");
+
+    try
+    {
+        var ok = svc.UpdateChecklistItemTitle(id, body.Title);
+        return ok ? Results.Ok() : Results.NotFound();
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ex.Message);
+    }
+});
+app.MapPut("api/quick-tasks/{id:int}/checklist/reorder", async (int id, QuickTaskService svc, HttpRequest req) =>
+{
+    var body = await req.ReadFromJsonAsync<ReorderQuickTaskChecklistRequest>();
+    if (body == null || body.ChecklistOrders == null || body.ChecklistOrders.Count == 0)
+        return Results.BadRequest("checklistOrders required");
+
+    try
+    {
+        svc.ReorderChecklist(id, body.ChecklistOrders);
+        return Results.Ok();
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ex.Message);
+    }
+});
+app.MapDelete("api/quick-task-checklist/{id:int}", (int id, QuickTaskService svc) =>
+{
+    try
+    {
+        var ok = svc.DeleteChecklistItem(id);
+        return ok ? Results.Ok() : Results.NotFound();
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ex.Message);
+    }
+});
+
 // Warm slow comment counts in the background so initial UI badges appear faster
 // after startup and auto-refresh has warm cache to read from.
 _ = Task.Run(async () =>
@@ -529,3 +709,11 @@ public record ReorderSubtasksRequest(Dictionary<int, int> SubtaskOrders);
 public record ReorderCommentSubtasksRequest(Dictionary<int, int> SubtaskOrders);
 public record UpdateBoardColumnRequest(string? Column);
 public record UpdateWorkingOnRequest(bool IsWorkingOn);
+public record AddQuickTaskRequest(string Title);
+public record UpdateQuickTaskTitleRequest(string Title);
+public record ToggleQuickTaskRequest(bool IsCompleted);
+public record AddQuickTaskCommentRequest(string Content);
+public record AddQuickTaskChecklistItemRequest(string Title, int? Order);
+public record ToggleQuickTaskChecklistItemRequest(bool IsCompleted);
+public record UpdateQuickTaskChecklistItemTitleRequest(string Title);
+public record ReorderQuickTaskChecklistRequest(Dictionary<int, int> ChecklistOrders);

--- a/backend/src/Taskify.Infrastructure/Storage/QuickTaskService.cs
+++ b/backend/src/Taskify.Infrastructure/Storage/QuickTaskService.cs
@@ -49,6 +49,19 @@ public class QuickTaskService
         return _store.AddTaskComment(taskId, trimmed);
     }
 
+    public bool UpdateTaskComment(int commentId, string content)
+    {
+        EnsurePositive(commentId, "Comment ID");
+        var trimmed = ValidateComment(content);
+        return _store.SetTaskCommentContent(commentId, trimmed);
+    }
+
+    public bool DeleteTaskComment(int commentId)
+    {
+        EnsurePositive(commentId, "Comment ID");
+        return _store.DeleteTaskComment(commentId);
+    }
+
     public List<QuickTaskChecklistItem> GetTaskChecklist(int taskId)
     {
         EnsurePositive(taskId, "Task ID");

--- a/backend/src/Taskify.Infrastructure/Storage/QuickTaskService.cs
+++ b/backend/src/Taskify.Infrastructure/Storage/QuickTaskService.cs
@@ -1,0 +1,122 @@
+namespace Taskify.Infrastructure.Storage;
+
+public class QuickTaskService
+{
+    private readonly QuickTaskStore _store;
+
+    public QuickTaskService(QuickTaskStore store)
+    {
+        _store = store;
+    }
+
+    public List<QuickTaskItem> GetTasks() => _store.GetTasks();
+
+    public QuickTaskItem AddTask(string title)
+    {
+        var trimmed = ValidateTitle(title, "Task title");
+        return _store.AddTask(trimmed);
+    }
+
+    public bool UpdateTaskTitle(int taskId, string title)
+    {
+        EnsurePositive(taskId, "Task ID");
+        var trimmed = ValidateTitle(title, "Task title");
+        return _store.UpdateTaskTitle(taskId, trimmed);
+    }
+
+    public bool ToggleTaskCompletion(int taskId, bool isCompleted)
+    {
+        EnsurePositive(taskId, "Task ID");
+        return _store.SetTaskCompletion(taskId, isCompleted);
+    }
+
+    public bool DeleteTask(int taskId)
+    {
+        EnsurePositive(taskId, "Task ID");
+        return _store.DeleteTask(taskId);
+    }
+
+    public List<QuickTaskCommentItem> GetTaskComments(int taskId)
+    {
+        EnsurePositive(taskId, "Task ID");
+        return _store.GetTaskComments(taskId);
+    }
+
+    public QuickTaskCommentItem AddTaskComment(int taskId, string content)
+    {
+        EnsurePositive(taskId, "Task ID");
+        var trimmed = ValidateComment(content);
+        return _store.AddTaskComment(taskId, trimmed);
+    }
+
+    public List<QuickTaskChecklistItem> GetTaskChecklist(int taskId)
+    {
+        EnsurePositive(taskId, "Task ID");
+        return _store.GetTaskChecklist(taskId);
+    }
+
+    public QuickTaskChecklistItem AddChecklistItem(int taskId, string title, int? order = null)
+    {
+        EnsurePositive(taskId, "Task ID");
+        var trimmed = ValidateTitle(title, "Checklist title");
+        return _store.AddChecklistItem(taskId, trimmed, order);
+    }
+
+    public bool ToggleChecklistItem(int checklistItemId, bool isCompleted)
+    {
+        EnsurePositive(checklistItemId, "Checklist item ID");
+        return _store.SetChecklistCompletion(checklistItemId, isCompleted);
+    }
+
+    public bool UpdateChecklistItemTitle(int checklistItemId, string title)
+    {
+        EnsurePositive(checklistItemId, "Checklist item ID");
+        var trimmed = ValidateTitle(title, "Checklist title");
+        return _store.SetChecklistTitle(checklistItemId, trimmed);
+    }
+
+    public bool DeleteChecklistItem(int checklistItemId)
+    {
+        EnsurePositive(checklistItemId, "Checklist item ID");
+        return _store.DeleteChecklistItem(checklistItemId);
+    }
+
+    public void ReorderChecklist(int taskId, Dictionary<int, int> checklistOrders)
+    {
+        EnsurePositive(taskId, "Task ID");
+        if (checklistOrders == null || checklistOrders.Count == 0)
+            throw new ArgumentException("Checklist order mapping cannot be empty", nameof(checklistOrders));
+
+        _store.ReorderChecklist(taskId, checklistOrders);
+    }
+
+    private static string ValidateTitle(string? title, string label)
+    {
+        if (string.IsNullOrWhiteSpace(title))
+            throw new ArgumentException($"{label} cannot be empty");
+
+        var trimmed = title.Trim();
+        if (trimmed.Length > 200)
+            throw new ArgumentException($"{label} cannot exceed 200 characters");
+
+        return trimmed;
+    }
+
+    private static string ValidateComment(string? content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            throw new ArgumentException("Comment content cannot be empty");
+
+        var trimmed = content.Trim();
+        if (trimmed.Length > 5000)
+            throw new ArgumentException("Comment content cannot exceed 5000 characters");
+
+        return trimmed;
+    }
+
+    private static void EnsurePositive(int id, string label)
+    {
+        if (id <= 0)
+            throw new ArgumentException($"{label} must be positive");
+    }
+}

--- a/backend/src/Taskify.Infrastructure/Storage/QuickTaskStore.cs
+++ b/backend/src/Taskify.Infrastructure/Storage/QuickTaskStore.cs
@@ -141,6 +141,44 @@ public class QuickTaskStore
         }
     }
 
+    public bool SetTaskCommentContent(int commentId, string content)
+    {
+        lock (_syncRoot)
+        {
+            foreach (var task in _model.Tasks)
+            {
+                var comment = task.Comments.FirstOrDefault(c => c.Id == commentId);
+                if (comment == null)
+                    continue;
+
+                comment.Content = content;
+                Persist();
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    public bool DeleteTaskComment(int commentId)
+    {
+        lock (_syncRoot)
+        {
+            foreach (var task in _model.Tasks)
+            {
+                var comment = task.Comments.FirstOrDefault(c => c.Id == commentId);
+                if (comment == null)
+                    continue;
+
+                task.Comments.Remove(comment);
+                Persist();
+                return true;
+            }
+
+            return false;
+        }
+    }
+
     public List<QuickTaskChecklistItem> GetTaskChecklist(int taskId)
     {
         lock (_syncRoot)

--- a/backend/src/Taskify.Infrastructure/Storage/QuickTaskStore.cs
+++ b/backend/src/Taskify.Infrastructure/Storage/QuickTaskStore.cs
@@ -1,0 +1,426 @@
+using System.Text.Json;
+
+namespace Taskify.Infrastructure.Storage;
+
+public class QuickTaskStore
+{
+    private readonly string _storageFilePath;
+    private readonly object _syncRoot = new();
+    private QuickTaskStoreModel _model;
+
+    public QuickTaskStore(string storageDirectory = "storage")
+    {
+        if (!Path.IsPathRooted(storageDirectory))
+            storageDirectory = Path.Combine(AppContext.BaseDirectory, storageDirectory);
+
+        if (!Directory.Exists(storageDirectory))
+            Directory.CreateDirectory(storageDirectory);
+
+        _storageFilePath = Path.Combine(storageDirectory, "quick_tasks.json");
+        _model = Load();
+    }
+
+    public List<QuickTaskItem> GetTasks()
+    {
+        lock (_syncRoot)
+        {
+            return _model.Tasks
+                .Select(CloneTask)
+                .OrderBy(t => t.IsCompleted)
+                .ThenByDescending(t => t.CreatedDate)
+                .ToList();
+        }
+    }
+
+    public QuickTaskItem AddTask(string title)
+    {
+        lock (_syncRoot)
+        {
+            var now = DateTime.UtcNow;
+            var task = new QuickTaskModel
+            {
+                Id = _model.NextTaskId++,
+                Title = title,
+                IsCompleted = false,
+                CreatedDate = now
+            };
+            _model.Tasks.Add(task);
+            Persist();
+            return CloneTask(task);
+        }
+    }
+
+    public bool UpdateTaskTitle(int taskId, string title)
+    {
+        lock (_syncRoot)
+        {
+            var task = _model.Tasks.FirstOrDefault(t => t.Id == taskId);
+            if (task == null)
+                return false;
+
+            task.Title = title;
+            Persist();
+            return true;
+        }
+    }
+
+    public bool SetTaskCompletion(int taskId, bool isCompleted)
+    {
+        lock (_syncRoot)
+        {
+            var task = _model.Tasks.FirstOrDefault(t => t.Id == taskId);
+            if (task == null)
+                return false;
+
+            task.IsCompleted = isCompleted;
+            task.CompletedDate = isCompleted ? DateTime.UtcNow : null;
+            Persist();
+            return true;
+        }
+    }
+
+    public bool DeleteTask(int taskId)
+    {
+        lock (_syncRoot)
+        {
+            var task = _model.Tasks.FirstOrDefault(t => t.Id == taskId);
+            if (task == null)
+                return false;
+
+            _model.Tasks.Remove(task);
+            Persist();
+            return true;
+        }
+    }
+
+    public List<QuickTaskCommentItem> GetTaskComments(int taskId)
+    {
+        lock (_syncRoot)
+        {
+            var task = _model.Tasks.FirstOrDefault(t => t.Id == taskId);
+            if (task == null)
+                return new List<QuickTaskCommentItem>();
+
+            return task.Comments
+                .OrderBy(c => c.CreatedDate)
+                .Select(c => new QuickTaskCommentItem
+                {
+                    Id = c.Id,
+                    TaskId = taskId,
+                    Content = c.Content,
+                    CreatedDate = c.CreatedDate
+                })
+                .ToList();
+        }
+    }
+
+    public QuickTaskCommentItem AddTaskComment(int taskId, string content)
+    {
+        lock (_syncRoot)
+        {
+            var task = _model.Tasks.FirstOrDefault(t => t.Id == taskId);
+            if (task == null)
+                throw new ArgumentException("Task not found", nameof(taskId));
+
+            var comment = new QuickTaskCommentModel
+            {
+                Id = _model.NextCommentId++,
+                Content = content,
+                CreatedDate = DateTime.UtcNow
+            };
+            task.Comments.Add(comment);
+            Persist();
+
+            return new QuickTaskCommentItem
+            {
+                Id = comment.Id,
+                TaskId = taskId,
+                Content = comment.Content,
+                CreatedDate = comment.CreatedDate
+            };
+        }
+    }
+
+    public List<QuickTaskChecklistItem> GetTaskChecklist(int taskId)
+    {
+        lock (_syncRoot)
+        {
+            var task = _model.Tasks.FirstOrDefault(t => t.Id == taskId);
+            if (task == null)
+                return new List<QuickTaskChecklistItem>();
+
+            return task.Checklist
+                .OrderBy(i => i.Order)
+                .Select(i => new QuickTaskChecklistItem
+                {
+                    Id = i.Id,
+                    TaskId = taskId,
+                    Title = i.Title,
+                    IsCompleted = i.IsCompleted,
+                    Order = i.Order,
+                    CreatedDate = i.CreatedDate,
+                    CompletedDate = i.CompletedDate
+                })
+                .ToList();
+        }
+    }
+
+    public QuickTaskChecklistItem AddChecklistItem(int taskId, string title, int? order = null)
+    {
+        lock (_syncRoot)
+        {
+            var task = _model.Tasks.FirstOrDefault(t => t.Id == taskId);
+            if (task == null)
+                throw new ArgumentException("Task not found", nameof(taskId));
+
+            var newOrder = order ?? (task.Checklist.Count == 0 ? 0 : task.Checklist.Max(i => i.Order) + 1);
+            var item = new QuickTaskChecklistItemModel
+            {
+                Id = _model.NextChecklistId++,
+                Title = title,
+                IsCompleted = false,
+                Order = newOrder,
+                CreatedDate = DateTime.UtcNow
+            };
+
+            task.Checklist.Add(item);
+            Persist();
+
+            return new QuickTaskChecklistItem
+            {
+                Id = item.Id,
+                TaskId = taskId,
+                Title = item.Title,
+                IsCompleted = item.IsCompleted,
+                Order = item.Order,
+                CreatedDate = item.CreatedDate
+            };
+        }
+    }
+
+    public bool SetChecklistCompletion(int checklistItemId, bool isCompleted)
+    {
+        lock (_syncRoot)
+        {
+            foreach (var task in _model.Tasks)
+            {
+                var item = task.Checklist.FirstOrDefault(i => i.Id == checklistItemId);
+                if (item == null)
+                    continue;
+
+                item.IsCompleted = isCompleted;
+                item.CompletedDate = isCompleted ? DateTime.UtcNow : null;
+                Persist();
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    public bool SetChecklistTitle(int checklistItemId, string title)
+    {
+        lock (_syncRoot)
+        {
+            foreach (var task in _model.Tasks)
+            {
+                var item = task.Checklist.FirstOrDefault(i => i.Id == checklistItemId);
+                if (item == null)
+                    continue;
+
+                item.Title = title;
+                Persist();
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    public bool ReorderChecklist(int taskId, Dictionary<int, int> checklistItemToOrder)
+    {
+        lock (_syncRoot)
+        {
+            var task = _model.Tasks.FirstOrDefault(t => t.Id == taskId);
+            if (task == null)
+                return false;
+
+            foreach (var kvp in checklistItemToOrder)
+            {
+                var item = task.Checklist.FirstOrDefault(i => i.Id == kvp.Key);
+                if (item != null)
+                    item.Order = kvp.Value;
+            }
+
+            Persist();
+            return true;
+        }
+    }
+
+    public bool DeleteChecklistItem(int checklistItemId)
+    {
+        lock (_syncRoot)
+        {
+            foreach (var task in _model.Tasks)
+            {
+                var item = task.Checklist.FirstOrDefault(i => i.Id == checklistItemId);
+                if (item == null)
+                    continue;
+
+                task.Checklist.Remove(item);
+                Persist();
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    private static QuickTaskItem CloneTask(QuickTaskModel model)
+    {
+        return new QuickTaskItem
+        {
+            Id = model.Id,
+            Title = model.Title,
+            IsCompleted = model.IsCompleted,
+            CreatedDate = model.CreatedDate,
+            CompletedDate = model.CompletedDate,
+            Comments = model.Comments
+                .OrderBy(c => c.CreatedDate)
+                .Select(c => new QuickTaskCommentItem
+                {
+                    Id = c.Id,
+                    TaskId = model.Id,
+                    Content = c.Content,
+                    CreatedDate = c.CreatedDate
+                })
+                .ToList(),
+            Checklist = model.Checklist
+                .OrderBy(i => i.Order)
+                .Select(i => new QuickTaskChecklistItem
+                {
+                    Id = i.Id,
+                    TaskId = model.Id,
+                    Title = i.Title,
+                    IsCompleted = i.IsCompleted,
+                    Order = i.Order,
+                    CreatedDate = i.CreatedDate,
+                    CompletedDate = i.CompletedDate
+                })
+                .ToList()
+        };
+    }
+
+    private QuickTaskStoreModel Load()
+    {
+        try
+        {
+            if (File.Exists(_storageFilePath))
+            {
+                var json = File.ReadAllText(_storageFilePath);
+                var loaded = JsonSerializer.Deserialize<QuickTaskStoreModel>(json);
+                if (loaded != null)
+                {
+                    loaded.Tasks ??= new List<QuickTaskModel>();
+                    foreach (var task in loaded.Tasks)
+                    {
+                        task.Comments ??= new List<QuickTaskCommentModel>();
+                        task.Checklist ??= new List<QuickTaskChecklistItemModel>();
+                    }
+                    return loaded;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Warning: Failed to load quick tasks: {ex.Message}");
+        }
+
+        return new QuickTaskStoreModel
+        {
+            NextTaskId = 1,
+            NextCommentId = 1,
+            NextChecklistId = 1,
+            Tasks = new List<QuickTaskModel>()
+        };
+    }
+
+    private void Persist()
+    {
+        try
+        {
+            var json = JsonSerializer.Serialize(_model, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(_storageFilePath, json);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Warning: Failed to persist quick tasks: {ex.Message}");
+        }
+    }
+
+    private class QuickTaskStoreModel
+    {
+        public int NextTaskId { get; set; }
+        public int NextCommentId { get; set; }
+        public int NextChecklistId { get; set; }
+        public List<QuickTaskModel> Tasks { get; set; } = new();
+    }
+
+    private class QuickTaskModel
+    {
+        public int Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public bool IsCompleted { get; set; }
+        public DateTime CreatedDate { get; set; }
+        public DateTime? CompletedDate { get; set; }
+        public List<QuickTaskCommentModel> Comments { get; set; } = new();
+        public List<QuickTaskChecklistItemModel> Checklist { get; set; } = new();
+    }
+
+    private class QuickTaskCommentModel
+    {
+        public int Id { get; set; }
+        public string Content { get; set; } = string.Empty;
+        public DateTime CreatedDate { get; set; }
+    }
+
+    private class QuickTaskChecklistItemModel
+    {
+        public int Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public bool IsCompleted { get; set; }
+        public int Order { get; set; }
+        public DateTime CreatedDate { get; set; }
+        public DateTime? CompletedDate { get; set; }
+    }
+}
+
+public class QuickTaskItem
+{
+    public int Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public bool IsCompleted { get; set; }
+    public DateTime CreatedDate { get; set; }
+    public DateTime? CompletedDate { get; set; }
+    public List<QuickTaskCommentItem> Comments { get; set; } = new();
+    public List<QuickTaskChecklistItem> Checklist { get; set; } = new();
+}
+
+public class QuickTaskCommentItem
+{
+    public int Id { get; set; }
+    public int TaskId { get; set; }
+    public string Content { get; set; } = string.Empty;
+    public DateTime CreatedDate { get; set; }
+}
+
+public class QuickTaskChecklistItem
+{
+    public int Id { get; set; }
+    public int TaskId { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public bool IsCompleted { get; set; }
+    public int Order { get; set; }
+    public DateTime CreatedDate { get; set; }
+    public DateTime? CompletedDate { get; set; }
+}

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -190,6 +190,177 @@
   margin-left: 0.2rem;
 }
 
+.quick-tasks-panel {
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 12px;
+  padding: 0.8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.quick-tasks-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.quick-tasks-header h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.quick-tasks-count {
+  background: rgba(56, 189, 248, 0.2);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  color: #7dd3fc;
+  font-size: 0.75rem;
+  border-radius: 999px;
+  padding: 0.15rem 0.55rem;
+}
+
+.quick-task-add-row,
+.quick-task-add-inline {
+  display: flex;
+  gap: 0.45rem;
+}
+
+.quick-task-input,
+.quick-task-add-inline input,
+.quick-task-checklist-edit-input {
+  flex: 1;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 8px;
+  color: rgba(255, 255, 255, 0.92);
+  padding: 0.45rem 0.6rem;
+  font-size: 0.82rem;
+}
+
+.quick-task-add-btn,
+.quick-task-add-inline button,
+.quick-task-checklist-item button,
+.quick-task-expand-btn,
+.quick-task-delete-btn {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.86);
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.77rem;
+  padding: 0.35rem 0.6rem;
+}
+
+.quick-task-delete-btn {
+  border-color: rgba(248, 113, 113, 0.35);
+  color: #fca5a5;
+}
+
+.quick-task-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.quick-task-card {
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 10px;
+  padding: 0.55rem;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.quick-task-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.quick-task-title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-width: 0;
+}
+
+.quick-task-title {
+  font-size: 0.86rem;
+  word-break: break-word;
+}
+
+.quick-task-title.done,
+.quick-task-checklist-item span.done {
+  text-decoration: line-through;
+  opacity: 0.66;
+}
+
+.quick-task-meta {
+  display: flex;
+  gap: 0.4rem;
+  flex-shrink: 0;
+}
+
+.quick-task-summary {
+  margin-top: 0.35rem;
+  color: rgba(255, 255, 255, 0.62);
+  font-size: 0.75rem;
+}
+
+.quick-task-details {
+  margin-top: 0.6rem;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+
+.quick-task-comments h4,
+.quick-task-checklist h4 {
+  margin: 0 0 0.4rem;
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.quick-task-items-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-bottom: 0.5rem;
+}
+
+.quick-task-comment-item {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.03);
+  padding: 0.36rem 0.5rem;
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.86);
+  white-space: pre-wrap;
+}
+
+.quick-task-checklist-item {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.03);
+  padding: 0.3rem 0.38rem;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.quick-task-checklist-item span {
+  flex: 1;
+  font-size: 0.78rem;
+  min-width: 0;
+  word-break: break-word;
+}
+
+.quick-tasks-empty,
+.quick-tasks-loading {
+  color: rgba(255, 255, 255, 0.62);
+  font-size: 0.8rem;
+}
+
 .assignments-list {
   display: flex;
   flex-direction: column;

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -238,6 +238,17 @@
   font-size: 0.82rem;
 }
 
+.quick-task-title-edit-input {
+  flex: 1;
+  min-width: 0;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 6px;
+  color: rgba(255, 255, 255, 0.92);
+  padding: 0.2rem 0.45rem;
+  font-size: 0.8rem;
+}
+
 .quick-task-add-btn,
 .quick-task-add-inline button,
 .quick-task-checklist-item button,
@@ -250,6 +261,23 @@
   cursor: pointer;
   font-size: 0.77rem;
   padding: 0.35rem 0.6rem;
+}
+
+.quick-task-inline-icon-btn {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.78);
+  border-radius: 6px;
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  font-size: 0.8rem;
+  flex-shrink: 0;
 }
 
 .quick-task-delete-btn {
@@ -333,9 +361,28 @@
   border-radius: 8px;
   background: rgba(255, 255, 255, 0.03);
   padding: 0.36rem 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.quick-task-comment-item span {
+  flex: 1;
   font-size: 0.78rem;
   color: rgba(255, 255, 255, 0.86);
   white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.quick-task-comment-edit-input {
+  flex: 1;
+  min-width: 0;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 6px;
+  color: rgba(255, 255, 255, 0.92);
+  padding: 0.22rem 0.4rem;
+  font-size: 0.77rem;
 }
 
 .quick-task-checklist-item {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import "./App.css";
 import AssignmentCard from "./components/AssignmentCard";
 import WorkingOnSection from "./components/WorkingOnSection";
+import QuickTasksSection from "./components/QuickTasksSection";
 
 const ASSIGNMENTS_API_URL = "http://localhost:5000/api/assignments";
 const LAST_SEEN_COMMENT_COUNTS_KEY = "lastSeenCommentCounts";
@@ -1325,6 +1326,7 @@ function App() {
 
       {!loading && !error && (
         <div className="assignments-container">
+          <QuickTasksSection />
           <div className="assignment-controls">
             <div className="assignment-search-container">
               <input

--- a/client/src/components/QuickTasksSection.jsx
+++ b/client/src/components/QuickTasksSection.jsx
@@ -1,0 +1,521 @@
+import React, { useEffect, useMemo, useState } from "react";
+
+const QUICK_TASKS_API_URL = "http://localhost:5000/api/quick-tasks";
+
+function QuickTasksSection() {
+  const [tasks, setTasks] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [newTaskTitle, setNewTaskTitle] = useState("");
+  const [openTaskDetails, setOpenTaskDetails] = useState({});
+  const [newComments, setNewComments] = useState({});
+  const [newChecklistItems, setNewChecklistItems] = useState({});
+  const [editingChecklistTitles, setEditingChecklistTitles] = useState({});
+  const [checklistDrafts, setChecklistDrafts] = useState({});
+  const [draggedChecklistItem, setDraggedChecklistItem] = useState(null);
+
+  const sortedTasks = useMemo(
+    () =>
+      [...tasks].sort((a, b) => {
+        if (a.isCompleted !== b.isCompleted) {
+          return Number(a.isCompleted) - Number(b.isCompleted);
+        }
+        return new Date(b.createdDate) - new Date(a.createdDate);
+      }),
+    [tasks]
+  );
+
+  useEffect(() => {
+    refreshTasks();
+  }, []);
+
+  const refreshTasks = async () => {
+    try {
+      const response = await fetch(QUICK_TASKS_API_URL);
+      if (!response.ok) throw new Error("Failed to fetch quick tasks");
+      const data = await response.json();
+      setTasks(Array.isArray(data) ? data : []);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleAddTask = async () => {
+    const title = newTaskTitle.trim();
+    if (!title) return;
+
+    try {
+      const response = await fetch(QUICK_TASKS_API_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title })
+      });
+      if (!response.ok) throw new Error("Failed to add quick task");
+      const created = await response.json();
+      setTasks((prev) => [created, ...prev]);
+      setNewTaskTitle("");
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleToggleTask = async (task, isCompleted) => {
+    try {
+      const response = await fetch(
+        `${QUICK_TASKS_API_URL}/${task.id}/toggle`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ isCompleted })
+        }
+      );
+      if (!response.ok) throw new Error("Failed to toggle quick task");
+
+      setTasks((prev) =>
+        prev.map((t) => (t.id === task.id ? { ...t, isCompleted } : t))
+      );
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleDeleteTask = async (taskId) => {
+    try {
+      const response = await fetch(`${QUICK_TASKS_API_URL}/${taskId}`, {
+        method: "DELETE"
+      });
+      if (!response.ok) throw new Error("Failed to delete quick task");
+      setTasks((prev) => prev.filter((t) => t.id !== taskId));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleAddComment = async (taskId) => {
+    const content = (newComments[taskId] || "").trim();
+    if (!content) return;
+
+    try {
+      const response = await fetch(`${QUICK_TASKS_API_URL}/${taskId}/comments`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content })
+      });
+      if (!response.ok) throw new Error("Failed to add quick task comment");
+      const created = await response.json();
+
+      setTasks((prev) =>
+        prev.map((task) =>
+          task.id === taskId
+            ? {
+                ...task,
+                comments: [...(task.comments || []), created]
+              }
+            : task
+        )
+      );
+      setNewComments((prev) => ({ ...prev, [taskId]: "" }));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleAddChecklistItem = async (taskId) => {
+    const title = (newChecklistItems[taskId] || "").trim();
+    if (!title) return;
+
+    try {
+      const response = await fetch(`${QUICK_TASKS_API_URL}/${taskId}/checklist`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title })
+      });
+      if (!response.ok) throw new Error("Failed to add checklist item");
+      const created = await response.json();
+
+      setTasks((prev) =>
+        prev.map((task) =>
+          task.id === taskId
+            ? {
+                ...task,
+                checklist: [...(task.checklist || []), created].sort(
+                  (a, b) => a.order - b.order
+                )
+              }
+            : task
+        )
+      );
+      setNewChecklistItems((prev) => ({ ...prev, [taskId]: "" }));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleToggleChecklistItem = async (taskId, itemId, isCompleted) => {
+    try {
+      const response = await fetch(
+        `http://localhost:5000/api/quick-task-checklist/${itemId}/toggle`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ isCompleted })
+        }
+      );
+      if (!response.ok) throw new Error("Failed to toggle checklist item");
+
+      setTasks((prev) =>
+        prev.map((task) =>
+          task.id === taskId
+            ? {
+                ...task,
+                checklist: (task.checklist || []).map((item) =>
+                  item.id === itemId ? { ...item, isCompleted } : item
+                )
+              }
+            : task
+        )
+      );
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleDeleteChecklistItem = async (taskId, itemId) => {
+    try {
+      const response = await fetch(
+        `http://localhost:5000/api/quick-task-checklist/${itemId}`,
+        { method: "DELETE" }
+      );
+      if (!response.ok) throw new Error("Failed to delete checklist item");
+
+      setTasks((prev) =>
+        prev.map((task) =>
+          task.id === taskId
+            ? {
+                ...task,
+                checklist: (task.checklist || []).filter((item) => item.id !== itemId)
+              }
+            : task
+        )
+      );
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const beginChecklistEdit = (itemId, currentTitle) => {
+    setEditingChecklistTitles((prev) => ({ ...prev, [itemId]: true }));
+    setChecklistDrafts((prev) => ({ ...prev, [itemId]: currentTitle || "" }));
+  };
+
+  const cancelChecklistEdit = (itemId) => {
+    setEditingChecklistTitles((prev) => ({ ...prev, [itemId]: false }));
+    setChecklistDrafts((prev) => {
+      const next = { ...prev };
+      delete next[itemId];
+      return next;
+    });
+  };
+
+  const saveChecklistEdit = async (taskId, itemId) => {
+    const title = (checklistDrafts[itemId] || "").trim();
+    if (!title) return;
+
+    try {
+      const response = await fetch(
+        `http://localhost:5000/api/quick-task-checklist/${itemId}/title`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title })
+        }
+      );
+      if (!response.ok) throw new Error("Failed to update checklist title");
+
+      setTasks((prev) =>
+        prev.map((task) =>
+          task.id === taskId
+            ? {
+                ...task,
+                checklist: (task.checklist || []).map((item) =>
+                  item.id === itemId ? { ...item, title } : item
+                )
+              }
+            : task
+        )
+      );
+      cancelChecklistEdit(itemId);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleChecklistDrop = async (taskId, targetItemId) => {
+    if (!draggedChecklistItem) return;
+    if (draggedChecklistItem.taskId !== taskId) return;
+    if (draggedChecklistItem.itemId === targetItemId) return;
+
+    const task = tasks.find((t) => t.id === taskId);
+    if (!task) return;
+
+    const items = [...(task.checklist || [])].sort((a, b) => a.order - b.order);
+    const sourceIndex = items.findIndex((i) => i.id === draggedChecklistItem.itemId);
+    const targetIndex = items.findIndex((i) => i.id === targetItemId);
+    if (sourceIndex < 0 || targetIndex < 0) return;
+
+    const reordered = [...items];
+    const [moved] = reordered.splice(sourceIndex, 1);
+    reordered.splice(targetIndex, 0, moved);
+    const normalized = reordered.map((item, idx) => ({ ...item, order: idx }));
+
+    setTasks((prev) =>
+      prev.map((t) => (t.id === taskId ? { ...t, checklist: normalized } : t))
+    );
+
+    const checklistOrders = {};
+    normalized.forEach((item, idx) => {
+      checklistOrders[item.id] = idx;
+    });
+
+    try {
+      await fetch(`${QUICK_TASKS_API_URL}/${taskId}/checklist/reorder`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ checklistOrders })
+      });
+    } catch (err) {
+      console.error("Failed to reorder checklist", err);
+    } finally {
+      setDraggedChecklistItem(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <section className="quick-tasks-panel">
+        <h2>Quick Tasks</h2>
+        <p className="quick-tasks-loading">Loading quick tasks...</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="quick-tasks-panel">
+      <div className="quick-tasks-header">
+        <h2>Quick Tasks</h2>
+        <span className="quick-tasks-count">{sortedTasks.length}</span>
+      </div>
+
+      <div className="quick-task-add-row">
+        <input
+          type="text"
+          className="quick-task-input"
+          placeholder="Add a quick task..."
+          value={newTaskTitle}
+          onChange={(e) => setNewTaskTitle(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleAddTask();
+            }
+          }}
+        />
+        <button className="quick-task-add-btn" onClick={handleAddTask}>
+          Add
+        </button>
+      </div>
+
+      <div className="quick-task-list">
+        {sortedTasks.length === 0 && (
+          <p className="quick-tasks-empty">No quick tasks yet.</p>
+        )}
+
+        {sortedTasks.map((task) => {
+          const comments = task.comments || [];
+          const checklist = [...(task.checklist || [])].sort(
+            (a, b) => a.order - b.order
+          );
+          const completedChecklist = checklist.filter((i) => i.isCompleted).length;
+
+          return (
+            <article key={task.id} className="quick-task-card">
+              <div className="quick-task-row">
+                <label className="quick-task-title-row">
+                  <input
+                    type="checkbox"
+                    checked={task.isCompleted}
+                    onChange={(e) => handleToggleTask(task, e.target.checked)}
+                  />
+                  <span className={task.isCompleted ? "quick-task-title done" : "quick-task-title"}>
+                    {task.title}
+                  </span>
+                </label>
+
+                <div className="quick-task-meta">
+                  <button
+                    className="quick-task-expand-btn"
+                    onClick={() =>
+                      setOpenTaskDetails((prev) => ({
+                        ...prev,
+                        [task.id]: !prev[task.id]
+                      }))
+                    }
+                  >
+                    {openTaskDetails[task.id] ? "Hide" : "Details"}
+                  </button>
+                  <button
+                    className="quick-task-delete-btn"
+                    onClick={() => handleDeleteTask(task.id)}
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+
+              <div className="quick-task-summary">
+                💬 {comments.length} comments · ☑ {completedChecklist}/{checklist.length}
+              </div>
+
+              {openTaskDetails[task.id] && (
+                <div className="quick-task-details">
+                  <div className="quick-task-comments">
+                    <h4>Comments</h4>
+                    <div className="quick-task-items-list">
+                      {comments.map((comment) => (
+                        <div key={comment.id} className="quick-task-comment-item">
+                          {comment.content}
+                        </div>
+                      ))}
+                    </div>
+                    <div className="quick-task-add-inline">
+                      <input
+                        type="text"
+                        placeholder="Add comment..."
+                        value={newComments[task.id] || ""}
+                        onChange={(e) =>
+                          setNewComments((prev) => ({
+                            ...prev,
+                            [task.id]: e.target.value
+                          }))
+                        }
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
+                            e.preventDefault();
+                            handleAddComment(task.id);
+                          }
+                        }}
+                      />
+                      <button onClick={() => handleAddComment(task.id)}>Add</button>
+                    </div>
+                  </div>
+
+                  <div className="quick-task-checklist">
+                    <h4>Checklist</h4>
+                    <div className="quick-task-items-list">
+                      {checklist.map((item) => (
+                        <div
+                          key={item.id}
+                          className="quick-task-checklist-item"
+                          draggable
+                          onDragStart={() =>
+                            setDraggedChecklistItem({ taskId: task.id, itemId: item.id })
+                          }
+                          onDragOver={(e) => e.preventDefault()}
+                          onDrop={(e) => {
+                            e.preventDefault();
+                            handleChecklistDrop(task.id, item.id);
+                          }}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={item.isCompleted}
+                            onChange={(e) =>
+                              handleToggleChecklistItem(task.id, item.id, e.target.checked)
+                            }
+                          />
+                          {editingChecklistTitles[item.id] ? (
+                            <input
+                              className="quick-task-checklist-edit-input"
+                              value={checklistDrafts[item.id] || ""}
+                              onChange={(e) =>
+                                setChecklistDrafts((prev) => ({
+                                  ...prev,
+                                  [item.id]: e.target.value
+                                }))
+                              }
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") {
+                                  e.preventDefault();
+                                  saveChecklistEdit(task.id, item.id);
+                                } else if (e.key === "Escape") {
+                                  e.preventDefault();
+                                  cancelChecklistEdit(item.id);
+                                }
+                              }}
+                              autoFocus
+                            />
+                          ) : (
+                            <span className={item.isCompleted ? "done" : ""}>{item.title}</span>
+                          )}
+                          {editingChecklistTitles[item.id] ? (
+                            <>
+                              <button
+                                onClick={() => saveChecklistEdit(task.id, item.id)}
+                                title="Save"
+                              >
+                                ✓
+                              </button>
+                              <button onClick={() => cancelChecklistEdit(item.id)} title="Cancel">
+                                ↺
+                              </button>
+                            </>
+                          ) : (
+                            <button
+                              onClick={() => beginChecklistEdit(item.id, item.title)}
+                              title="Edit"
+                            >
+                              ✎
+                            </button>
+                          )}
+                          <button
+                            onClick={() => handleDeleteChecklistItem(task.id, item.id)}
+                            title="Delete"
+                          >
+                            ✕
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                    <div className="quick-task-add-inline">
+                      <input
+                        type="text"
+                        placeholder="Add checklist item..."
+                        value={newChecklistItems[task.id] || ""}
+                        onChange={(e) =>
+                          setNewChecklistItems((prev) => ({
+                            ...prev,
+                            [task.id]: e.target.value
+                          }))
+                        }
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
+                            e.preventDefault();
+                            handleAddChecklistItem(task.id);
+                          }
+                        }}
+                      />
+                      <button onClick={() => handleAddChecklistItem(task.id)}>Add</button>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+export default QuickTasksSection;

--- a/client/src/components/QuickTasksSection.jsx
+++ b/client/src/components/QuickTasksSection.jsx
@@ -9,8 +9,12 @@ function QuickTasksSection() {
   const [openTaskDetails, setOpenTaskDetails] = useState({});
   const [newComments, setNewComments] = useState({});
   const [newChecklistItems, setNewChecklistItems] = useState({});
+  const [editingTaskTitles, setEditingTaskTitles] = useState({});
+  const [taskTitleDrafts, setTaskTitleDrafts] = useState({});
   const [editingChecklistTitles, setEditingChecklistTitles] = useState({});
   const [checklistDrafts, setChecklistDrafts] = useState({});
+  const [editingCommentContent, setEditingCommentContent] = useState({});
+  const [commentDrafts, setCommentDrafts] = useState({});
   const [draggedChecklistItem, setDraggedChecklistItem] = useState(null);
 
   const sortedTasks = useMemo(
@@ -92,6 +96,41 @@ function QuickTasksSection() {
     }
   };
 
+  const beginTaskTitleEdit = (taskId, currentTitle) => {
+    setEditingTaskTitles((prev) => ({ ...prev, [taskId]: true }));
+    setTaskTitleDrafts((prev) => ({ ...prev, [taskId]: currentTitle || "" }));
+  };
+
+  const cancelTaskTitleEdit = (taskId) => {
+    setEditingTaskTitles((prev) => ({ ...prev, [taskId]: false }));
+    setTaskTitleDrafts((prev) => {
+      const next = { ...prev };
+      delete next[taskId];
+      return next;
+    });
+  };
+
+  const saveTaskTitleEdit = async (taskId) => {
+    const title = (taskTitleDrafts[taskId] || "").trim();
+    if (!title) return;
+
+    try {
+      const response = await fetch(`${QUICK_TASKS_API_URL}/${taskId}/title`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title })
+      });
+      if (!response.ok) throw new Error("Failed to update quick task title");
+
+      setTasks((prev) =>
+        prev.map((task) => (task.id === taskId ? { ...task, title } : task))
+      );
+      cancelTaskTitleEdit(taskId);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   const handleAddComment = async (taskId) => {
     const content = (newComments[taskId] || "").trim();
     if (!content) return;
@@ -116,6 +155,78 @@ function QuickTasksSection() {
         )
       );
       setNewComments((prev) => ({ ...prev, [taskId]: "" }));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const beginCommentEdit = (commentId, currentContent) => {
+    setEditingCommentContent((prev) => ({ ...prev, [commentId]: true }));
+    setCommentDrafts((prev) => ({ ...prev, [commentId]: currentContent || "" }));
+  };
+
+  const cancelCommentEdit = (commentId) => {
+    setEditingCommentContent((prev) => ({ ...prev, [commentId]: false }));
+    setCommentDrafts((prev) => {
+      const next = { ...prev };
+      delete next[commentId];
+      return next;
+    });
+  };
+
+  const saveCommentEdit = async (taskId, commentId) => {
+    const content = (commentDrafts[commentId] || "").trim();
+    if (!content) return;
+
+    try {
+      const response = await fetch(
+        `http://localhost:5000/api/quick-task-comments/${commentId}/content`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ content })
+        }
+      );
+      if (!response.ok) throw new Error("Failed to update quick task comment");
+
+      setTasks((prev) =>
+        prev.map((task) =>
+          task.id === taskId
+            ? {
+                ...task,
+                comments: (task.comments || []).map((comment) =>
+                  comment.id === commentId ? { ...comment, content } : comment
+                )
+              }
+            : task
+        )
+      );
+      cancelCommentEdit(commentId);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleDeleteComment = async (taskId, commentId) => {
+    try {
+      const response = await fetch(
+        `http://localhost:5000/api/quick-task-comments/${commentId}`,
+        { method: "DELETE" }
+      );
+      if (!response.ok) throw new Error("Failed to delete quick task comment");
+
+      setTasks((prev) =>
+        prev.map((task) =>
+          task.id === taskId
+            ? {
+                ...task,
+                comments: (task.comments || []).filter(
+                  (comment) => comment.id !== commentId
+                )
+              }
+            : task
+        )
+      );
     } catch (err) {
       console.error(err);
     }
@@ -347,12 +458,65 @@ function QuickTasksSection() {
                     checked={task.isCompleted}
                     onChange={(e) => handleToggleTask(task, e.target.checked)}
                   />
-                  <span className={task.isCompleted ? "quick-task-title done" : "quick-task-title"}>
-                    {task.title}
-                  </span>
+                  {editingTaskTitles[task.id] ? (
+                    <input
+                      className="quick-task-title-edit-input"
+                      value={taskTitleDrafts[task.id] || ""}
+                      onChange={(e) =>
+                        setTaskTitleDrafts((prev) => ({
+                          ...prev,
+                          [task.id]: e.target.value
+                        }))
+                      }
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          e.preventDefault();
+                          saveTaskTitleEdit(task.id);
+                        } else if (e.key === "Escape") {
+                          e.preventDefault();
+                          cancelTaskTitleEdit(task.id);
+                        }
+                      }}
+                      autoFocus
+                    />
+                  ) : (
+                    <span
+                      className={
+                        task.isCompleted ? "quick-task-title done" : "quick-task-title"
+                      }
+                    >
+                      {task.title}
+                    </span>
+                  )}
                 </label>
 
                 <div className="quick-task-meta">
+                  {editingTaskTitles[task.id] ? (
+                    <>
+                      <button
+                        className="quick-task-inline-icon-btn"
+                        onClick={() => saveTaskTitleEdit(task.id)}
+                        title="Save task title"
+                      >
+                        ✓
+                      </button>
+                      <button
+                        className="quick-task-inline-icon-btn"
+                        onClick={() => cancelTaskTitleEdit(task.id)}
+                        title="Cancel title edit"
+                      >
+                        ↺
+                      </button>
+                    </>
+                  ) : (
+                    <button
+                      className="quick-task-inline-icon-btn"
+                      onClick={() => beginTaskTitleEdit(task.id, task.title)}
+                      title="Edit task title"
+                    >
+                      ✎
+                    </button>
+                  )}
                   <button
                     className="quick-task-expand-btn"
                     onClick={() =>
@@ -384,7 +548,65 @@ function QuickTasksSection() {
                     <div className="quick-task-items-list">
                       {comments.map((comment) => (
                         <div key={comment.id} className="quick-task-comment-item">
-                          {comment.content}
+                          {editingCommentContent[comment.id] ? (
+                            <input
+                              className="quick-task-comment-edit-input"
+                              value={commentDrafts[comment.id] || ""}
+                              onChange={(e) =>
+                                setCommentDrafts((prev) => ({
+                                  ...prev,
+                                  [comment.id]: e.target.value
+                                }))
+                              }
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") {
+                                  e.preventDefault();
+                                  saveCommentEdit(task.id, comment.id);
+                                } else if (e.key === "Escape") {
+                                  e.preventDefault();
+                                  cancelCommentEdit(comment.id);
+                                }
+                              }}
+                              autoFocus
+                            />
+                          ) : (
+                            <span>{comment.content}</span>
+                          )}
+                          {editingCommentContent[comment.id] ? (
+                            <>
+                              <button
+                                className="quick-task-inline-icon-btn"
+                                onClick={() => saveCommentEdit(task.id, comment.id)}
+                                title="Save comment"
+                              >
+                                ✓
+                              </button>
+                              <button
+                                className="quick-task-inline-icon-btn"
+                                onClick={() => cancelCommentEdit(comment.id)}
+                                title="Cancel edit"
+                              >
+                                ↺
+                              </button>
+                            </>
+                          ) : (
+                            <button
+                              className="quick-task-inline-icon-btn"
+                              onClick={() =>
+                                beginCommentEdit(comment.id, comment.content)
+                              }
+                              title="Edit comment"
+                            >
+                              ✎
+                            </button>
+                          )}
+                          <button
+                            className="quick-task-inline-icon-btn"
+                            onClick={() => handleDeleteComment(task.id, comment.id)}
+                            title="Delete comment"
+                          >
+                            ✕
+                          </button>
                         </div>
                       ))}
                     </div>
@@ -461,17 +683,23 @@ function QuickTasksSection() {
                           {editingChecklistTitles[item.id] ? (
                             <>
                               <button
+                                className="quick-task-inline-icon-btn"
                                 onClick={() => saveChecklistEdit(task.id, item.id)}
                                 title="Save"
                               >
                                 ✓
                               </button>
-                              <button onClick={() => cancelChecklistEdit(item.id)} title="Cancel">
+                              <button
+                                className="quick-task-inline-icon-btn"
+                                onClick={() => cancelChecklistEdit(item.id)}
+                                title="Cancel"
+                              >
                                 ↺
                               </button>
                             </>
                           ) : (
                             <button
+                              className="quick-task-inline-icon-btn"
                               onClick={() => beginChecklistEdit(item.id, item.title)}
                               title="Edit"
                             >
@@ -479,6 +707,7 @@ function QuickTasksSection() {
                             </button>
                           )}
                           <button
+                            className="quick-task-inline-icon-btn"
                             onClick={() => handleDeleteChecklistItem(task.id, item.id)}
                             title="Delete"
                           >

--- a/docs/deployment/local-production.md
+++ b/docs/deployment/local-production.md
@@ -1,0 +1,72 @@
+# Local Production Deployment (M-Files)
+
+This guide runs Taskify locally in a production-style setup:
+
+- backend published build
+- frontend built assets served with `vite preview`
+- connector set to `MFiles`
+
+## Prerequisites
+
+- .NET 8 SDK
+- Node.js + npm
+- M-Files Desktop client installed
+- Access to the target vault GUID
+
+## 1) Build and publish backend
+
+From repo root:
+
+```bash
+cd backend
+dotnet publish "src/Taskify.Api/Taskify.Api.csproj" -c Release -o "publish/api"
+```
+
+## 2) Build frontend
+
+From repo root:
+
+```bash
+cd client
+npm install
+npm run build
+```
+
+## 3) Start backend (Production + MFiles)
+
+From repo root:
+
+```bash
+cd backend
+ASPNETCORE_ENVIRONMENT=Production ASPNETCORE_URLS=http://0.0.0.0:5000 Taskify__DataSource=MFiles MFiles__VaultGuid="{YOUR-VAULT-GUID}" dotnet "c:/TempRepos/Taskify/backend/publish/api/Taskify.Api.dll"
+```
+
+Backend health check:
+
+```bash
+curl http://localhost:5000/api/health
+```
+
+## 4) Start frontend preview
+
+From repo root:
+
+```bash
+cd client
+npm run preview -- --host 0.0.0.0 --port 4173
+```
+
+Open:
+
+- `http://localhost:4173`
+
+## 5) Stop services
+
+- Stop frontend preview process.
+- Stop backend `dotnet` process.
+
+On Windows PowerShell if needed:
+
+```powershell
+Get-Process dotnet,node | Stop-Process -Force
+```


### PR DESCRIPTION
## Summary
- add a local Quick Tasks feature with task creation/completion, local comments, and checklist management (including edit/delete/reorder)
- add follow-up UX improvements for quick tasks (comment edit/delete, title editing, and consistent icon button styling)
- restore and link local deployment docs to fix README deployment link 404

## Test plan
- [x] `dotnet build` (backend)
- [x] `npm run build` (client)
- [x] Verify `GET /api/quick-tasks` returns data successfully
- [x] In UI, add/edit/delete quick task title and comments
- [x] In UI, add/edit/toggle/delete/reorder quick task checklist items
- [x] Confirm README deployment link points to existing `docs/deployment/local-production.md`

Made with [Cursor](https://cursor.com)