### PR TITLE
feat(ui): keep assignment context and actions visible while scrolling

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -577,6 +577,27 @@
   margin-bottom: 0.75rem;
 }
 
+.assignment-context-header.sticky {
+  position: sticky;
+  top: max(var(--assignment-controls-offset, 90px), 11.5rem);
+  z-index: 25;
+  margin: 0.35rem -0.45rem 0.65rem;
+  padding: 0.45rem 0.45rem 0.4rem;
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+.assignment-context-header.sticky .assignment-header {
+  margin-bottom: 0.4rem;
+}
+
+.assignment-context-header.sticky .assignment-assignee-line {
+  margin-bottom: 0;
+}
+
 .assignment-title {
   font-size: 1.1rem;
   font-weight: 500;
@@ -624,6 +645,19 @@
   font-size: 0.85rem;
   color: rgba(255, 255, 255, 0.6);
   flex-wrap: wrap;
+}
+
+.assignment-meta.sticky-actions {
+  position: sticky;
+  top: calc(max(var(--assignment-controls-offset, 90px), 11.5rem) + 4.8rem);
+  z-index: 24;
+  margin: 0.3rem -0.45rem 0.75rem;
+  padding: 0.4rem 0.45rem;
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
 }
 
 .assignment-assignee-line {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -101,27 +101,33 @@ function App() {
     }
   );
   const [lastRefreshedAt, setLastRefreshedAt] = useState(null);
+  const [assignmentControlsOffset, setAssignmentControlsOffset] = useState(96);
+  const assignmentControlsRef = useRef(null);
   const commentCountsRequestInFlightRef = useRef(false);
   const attachmentCountsRequestInFlightRef = useRef(false);
 
   const refreshData = useCallback(async (isInitialLoad = false) => {
     try {
       const assignmentScopeQuery = showAllAssignments ? "?all=true" : "";
-      const [userRes, assignmentsRes, workingOnRes] =
-        await Promise.all([
-          fetch("http://localhost:5000/api/user/current"),
-          fetch(`${ASSIGNMENTS_API_URL}${assignmentScopeQuery}`),
-          fetch("http://localhost:5000/api/assignments/working-on")
-        ]);
-
-      if (userRes.ok) {
-        const userData = await userRes.json();
-        setCurrentUser(userData.userName);
-      }
+      const assignmentsRes = await fetch(
+        `${ASSIGNMENTS_API_URL}${assignmentScopeQuery}`
+      );
 
       if (!assignmentsRes.ok) throw new Error("Failed to fetch assignments");
       const assignmentsData = await assignmentsRes.json();
       setAssignments(assignmentsData);
+
+      // Do not block assignment render on user/working-on lookups.
+      fetch("http://localhost:5000/api/user/current")
+        .then((res) => (res.ok ? res.json() : null))
+        .then((userData) => {
+          if (userData?.userName) {
+            setCurrentUser(userData.userName);
+          }
+        })
+        .catch((err) =>
+          console.error("Error refreshing current user:", err)
+        );
 
       // Keep assignment loading fast; hydrate comment counts asynchronously.
       if (!commentCountsRequestInFlightRef.current) {
@@ -164,10 +170,16 @@ function App() {
           });
       }
 
-      if (workingOnRes.ok) {
-        const workingOnData = await workingOnRes.json();
-        setWorkingOn(new Set(workingOnData));
-      }
+      fetch("http://localhost:5000/api/assignments/working-on")
+        .then((res) => (res.ok ? res.json() : null))
+        .then((workingOnData) => {
+          if (Array.isArray(workingOnData)) {
+            setWorkingOn(new Set(workingOnData));
+          }
+        })
+        .catch((err) =>
+          console.error("Error refreshing working-on assignments:", err)
+        );
 
       setLastRefreshedAt(new Date().toISOString());
       setError(null);
@@ -264,6 +276,48 @@ function App() {
 
     return () => clearInterval(intervalId);
   }, [autoRefreshIntervalSeconds, refreshData]);
+
+  useEffect(() => {
+    const controlsEl = assignmentControlsRef.current;
+    if (!controlsEl) return undefined;
+
+    const cssLengthToPx = (rawValue) => {
+      const value = (rawValue || "").trim();
+      if (!value) return 0;
+      if (value.endsWith("px")) return Number.parseFloat(value) || 0;
+      if (value.endsWith("rem")) {
+        const rootFontSize =
+          Number.parseFloat(
+            window.getComputedStyle(document.documentElement).fontSize || "16"
+          ) || 16;
+        return (Number.parseFloat(value) || 0) * rootFontSize;
+      }
+      return Number.parseFloat(value) || 0;
+    };
+
+    const updateOffset = () => {
+      const styles = window.getComputedStyle(controlsEl);
+      const stickyTop = cssLengthToPx(styles.top);
+      const marginBottom = cssLengthToPx(styles.marginBottom);
+      const measured = Math.ceil(
+        controlsEl.getBoundingClientRect().height + stickyTop + marginBottom + 20
+      );
+      setAssignmentControlsOffset(Math.max(measured, 70));
+    };
+
+    updateOffset();
+
+    const observer = new ResizeObserver(() => {
+      updateOffset();
+    });
+    observer.observe(controlsEl);
+    window.addEventListener("resize", updateOffset);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", updateOffset);
+    };
+  }, []);
 
   useEffect(() => {
     return () => {
@@ -1325,9 +1379,12 @@ function App() {
       )}
 
       {!loading && !error && (
-        <div className="assignments-container">
+        <div
+          className="assignments-container"
+          style={{ "--assignment-controls-offset": `${assignmentControlsOffset}px` }}
+        >
           <QuickTasksSection />
-          <div className="assignment-controls">
+          <div className="assignment-controls" ref={assignmentControlsRef}>
             <div className="assignment-search-container">
               <input
                 type="text"

--- a/client/src/components/AssignmentCard.jsx
+++ b/client/src/components/AssignmentCard.jsx
@@ -89,42 +89,55 @@ function AssignmentCard({
     assignment.assignedTo && assignment.assignedTo.trim().length > 0
       ? assignment.assignedTo
       : "Unknown";
+  const hasExpandedDetails = Boolean(
+    openComments[assignment.id] ||
+      openSubtasks[assignment.id] ||
+      openAttachments[assignment.id]
+  );
 
   return (
     <div
       className={`assignment-card ${isWorkingOnCard ? "working-on" : ""} ${unread ? "has-unread-comments" : ""}`}
     >
-      <div className="assignment-header">
-        <div className="assignment-title-row">
-          <button
-            className={`working-on-toggle ${isWorkingOnCard ? "active" : ""}`}
-            onClick={() => handleToggleWorkingOn(assignment.id, !isWorkingOnCard)}
-            title={isWorkingOnCard ? "Remove from Hot Zone" : "Add to Hot Zone"}
+      <div
+        className={`assignment-context-header ${hasExpandedDetails ? "sticky" : ""}`}
+      >
+        <div className="assignment-header">
+          <div className="assignment-title-row">
+            <button
+              className={`working-on-toggle ${isWorkingOnCard ? "active" : ""}`}
+              onClick={() => handleToggleWorkingOn(assignment.id, !isWorkingOnCard)}
+              title={isWorkingOnCard ? "Remove from Hot Zone" : "Add to Hot Zone"}
+            >
+              {isWorkingOnCard ? "🔥" : "⭐"}
+            </button>
+            <h2 className="assignment-title">{assignment.title}</h2>
+            {unread && (
+              <span className="assignment-unread-comments-badge">New comments</span>
+            )}
+          </div>
+          <span
+            className="status-badge"
+            style={{ backgroundColor: getStatusColor(assignment.status) }}
           >
-            {isWorkingOnCard ? "🔥" : "⭐"}
-          </button>
-          <h2 className="assignment-title">{assignment.title}</h2>
-          {unread && (
-            <span className="assignment-unread-comments-badge">New comments</span>
-          )}
+            {getStatusLabel(assignment.status)}
+          </span>
         </div>
-        <span
-          className="status-badge"
-          style={{ backgroundColor: getStatusColor(assignment.status) }}
+        <p
+          className="assignment-assignee-line"
+          title={`Assigned to: ${assignedToLabel}`}
         >
-          {getStatusLabel(assignment.status)}
-        </span>
+          Assigned to: {assignedToLabel}
+        </p>
       </div>
-
-      <p className="assignment-assignee-line" title={`Assigned to: ${assignedToLabel}`}>
-        Assigned to: {assignedToLabel}
-      </p>
 
       {assignment.description && (
         <p className="assignment-description">{assignment.description}</p>
       )}
 
-      <div className="assignment-meta">
+      <div
+        className={`assignment-meta ${hasExpandedDetails ? "sticky-actions" : ""}`}
+      >
         {assignment.dueDate && (
           <span
             className={`due-date ${isOverdue(assignment.dueDate, assignment.status) ? "overdue" : ""}`}


### PR DESCRIPTION
## Summary
- add sticky assignment context (title/assignee/status) when details are expanded so users keep orientation in long cards
- add sticky assignment action controls so users can switch between comments, subtasks, and attachments while scrolling
- adjust assignment refresh rendering to prioritize assignment list load and hydrate slower secondary state in the background

## Test plan
- [x] `npm run build`
- [x] Expand comments/subtasks/attachments on a long assignment card and scroll down
- [x] Verify assignment context remains visible below top controls while scrolling
- [x] Verify action controls (Hide/Comments, Subtasks, Attachments) remain accessible while scrolling
- [x] Verify assignment list still renders quickly with user/working-on hydration happening asynchronously

Made with [Cursor](https://cursor.com)