### PR TITLE
docs(deployment): add persistent local hosting guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,12 @@ Automated code quality and coverage checks via GitHub Actions. Requires `SONAR_T
 
 ## Deployment
 
-For local production-style deployment (M-Files connector, published backend, and frontend preview), see:
+For local production-style deployment (M-Files connector, published backend, and frontend preview), including:
+
+- temporary terminal-run mode (stops when terminal closes), and
+- persistent local hosting mode (auto-start after reboot),
+
+see:
 
 - [`docs/deployment/local-production.md`](docs/deployment/local-production.md)
 

--- a/docs/deployment/local-production.md
+++ b/docs/deployment/local-production.md
@@ -1,10 +1,15 @@
 # Local Production Deployment (M-Files)
 
-This guide runs Taskify locally in a production-style setup:
+This guide covers two local deployment modes:
 
-- backend published build
-- frontend built assets served with `vite preview`
-- connector set to `MFiles`
+- **Terminal-run mode**: quickest setup, but services stop when terminal closes.
+- **Persistent mode**: services auto-start and survive terminal close/reboot.
+
+## Important behavior
+
+If you start backend/frontend directly in a terminal, those processes are attached to that terminal session. Closing the terminal stops the app. This is expected.
+
+Use **Persistent mode** if you need Taskify to stay available after terminal close or machine reboot.
 
 ## Prerequisites
 
@@ -13,7 +18,7 @@ This guide runs Taskify locally in a production-style setup:
 - M-Files Desktop client installed
 - Access to the target vault GUID
 
-## 1) Build and publish backend
+## Build artifacts (required for both modes)
 
 From repo root:
 
@@ -22,51 +27,98 @@ cd backend
 dotnet publish "src/Taskify.Api/Taskify.Api.csproj" -c Release -o "publish/api"
 ```
 
-## 2) Build frontend
-
-From repo root:
-
 ```bash
 cd client
 npm install
 npm run build
 ```
 
-## 3) Start backend (Production + MFiles)
+## Mode A: Terminal-run (quick test)
 
-From repo root:
+### Start backend (Production + MFiles)
 
 ```bash
 cd backend
 ASPNETCORE_ENVIRONMENT=Production ASPNETCORE_URLS=http://0.0.0.0:5000 Taskify__DataSource=MFiles MFiles__VaultGuid="{YOUR-VAULT-GUID}" dotnet "c:/TempRepos/Taskify/backend/publish/api/Taskify.Api.dll"
 ```
 
-Backend health check:
-
-```bash
-curl http://localhost:5000/api/health
-```
-
-## 4) Start frontend preview
-
-From repo root:
+### Start frontend
 
 ```bash
 cd client
 npm run preview -- --host 0.0.0.0 --port 4173
 ```
 
-Open:
+Open `http://localhost:4173`.
 
-- `http://localhost:4173`
+### Stop
 
-## 5) Stop services
-
-- Stop frontend preview process.
-- Stop backend `dotnet` process.
-
-On Windows PowerShell if needed:
+Close the terminals, or run:
 
 ```powershell
 Get-Process dotnet,node | Stop-Process -Force
+```
+
+## Mode B: Persistent local hosting (recommended)
+
+This mode uses startup scripts + Windows Task Scheduler so Taskify auto-starts at login and remains running independently of interactive terminals.
+
+### 1) Create startup scripts
+
+Create `scripts/deployment/start-taskify-api.ps1`:
+
+```powershell
+$env:ASPNETCORE_ENVIRONMENT = "Production"
+$env:ASPNETCORE_URLS = "http://0.0.0.0:5000"
+$env:Taskify__DataSource = "MFiles"
+$env:MFiles__VaultGuid = "{YOUR-VAULT-GUID}"
+
+Set-Location "C:\TempRepos\Taskify\backend\publish\api"
+dotnet "C:\TempRepos\Taskify\backend\publish\api\Taskify.Api.dll"
+```
+
+Create `scripts/deployment/start-taskify-web.ps1`:
+
+```powershell
+Set-Location "C:\TempRepos\Taskify\client"
+npm run preview -- --host 0.0.0.0 --port 4173
+```
+
+### 2) Register startup tasks (run PowerShell as Administrator)
+
+```powershell
+$apiAction = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-NoProfile -ExecutionPolicy Bypass -File C:\TempRepos\Taskify\scripts\deployment\start-taskify-api.ps1"
+$webAction = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-NoProfile -ExecutionPolicy Bypass -File C:\TempRepos\Taskify\scripts\deployment\start-taskify-web.ps1"
+$trigger = New-ScheduledTaskTrigger -AtLogOn
+
+Register-ScheduledTask -TaskName "Taskify-API" -Action $apiAction -Trigger $trigger -Description "Start Taskify backend API at logon" -Force
+Register-ScheduledTask -TaskName "Taskify-Web" -Action $webAction -Trigger $trigger -Description "Start Taskify frontend preview at logon" -Force
+```
+
+### 3) Start immediately (without waiting for next login)
+
+```powershell
+Start-ScheduledTask -TaskName "Taskify-API"
+Start-ScheduledTask -TaskName "Taskify-Web"
+```
+
+### 4) Verify and reboot test
+
+Health checks:
+
+```bash
+curl http://localhost:5000/api/health
+curl http://localhost:4173
+```
+
+Reboot machine, sign in, then re-run the checks. If both endpoints respond, persistent startup is working.
+
+### 5) Manage/stop persistent tasks
+
+```powershell
+Stop-ScheduledTask -TaskName "Taskify-API"
+Stop-ScheduledTask -TaskName "Taskify-Web"
+
+Unregister-ScheduledTask -TaskName "Taskify-API" -Confirm:$false
+Unregister-ScheduledTask -TaskName "Taskify-Web" -Confirm:$false
 ```


### PR DESCRIPTION
## Summary
- clarify terminal-run deployment behavior (closing terminal stops backend/frontend processes)
- add persistent local hosting guidance using startup scripts and Windows Task Scheduler
- include reboot validation steps and stop/unregister instructions for local service-like hosting

## Test plan
- [x] Review README deployment section for terminal-run vs persistent mode clarity
- [x] Validate `docs/deployment/local-production.md` includes startup, reboot, verification, and cleanup steps
- [x] Verify deployment doc link in README still points to an existing file

Made with [Cursor](https://cursor.com)