### PR TITLE
fix(assignments): stabilize Team badge counts and cache attachment totals

### DIFF
--- a/backend/src/Taskify.Api/Program.cs
+++ b/backend/src/Taskify.Api/Program.cs
@@ -73,6 +73,8 @@ builder.Services.AddMemoryCache();
 var app = builder.Build();
 const string CommentCountsMineCacheKey = "comment-counts:mine";
 const string CommentCountsAllCacheKey = "comment-counts:all";
+const string AttachmentCountsMineCacheKey = "attachment-counts:mine";
+const string AttachmentCountsAllCacheKey = "attachment-counts:all";
 
 app.UseCors();
 
@@ -160,7 +162,7 @@ app.MapGet("api/assignments/{id:int}/attachments", async (int id, ITaskDataSourc
         return Results.BadRequest($"Error getting attachments: {ex.Message}");
     }
 });
-app.MapPost("api/assignments/{id:int}/attachments", async (int id, ITaskDataSource ds, HttpRequest req) =>
+app.MapPost("api/assignments/{id:int}/attachments", async (int id, ITaskDataSource ds, IMemoryCache cache, HttpRequest req) =>
 {
     if (!req.HasFormContentType)
         return Results.BadRequest("multipart/form-data required");
@@ -181,6 +183,8 @@ app.MapPost("api/assignments/{id:int}/attachments", async (int id, ITaskDataSour
             file.FileName,
             file.ContentType ?? "application/octet-stream",
             ms.ToArray());
+        cache.Remove(AttachmentCountsMineCacheKey);
+        cache.Remove(AttachmentCountsAllCacheKey);
         return Results.Ok(attachment);
     }
     catch (Exception ex)
@@ -224,21 +228,16 @@ app.MapGet("api/assignments/comments/counts", async (bool? all, AssignmentServic
         return Results.BadRequest($"Error getting comment counts: {ex.Message}");
     }
 });
-app.MapGet("api/assignments/attachments/counts", async (bool? all, AssignmentService assignmentSvc, ITaskDataSource ds) =>
+app.MapGet("api/assignments/attachments/counts", async (bool? all, AssignmentService assignmentSvc, ITaskDataSource ds, IMemoryCache cache) =>
 {
+    var cacheKey = all == true ? AttachmentCountsAllCacheKey : AttachmentCountsMineCacheKey;
     try
     {
-        var assignments = all == true
-            ? assignmentSvc.GetAllAssignments()
-            : assignmentSvc.GetUserAssignments();
-
-        var counts = new Dictionary<int, int>();
-        foreach (var assignment in assignments)
-        {
-            var attachments = await ds.GetAttachmentsForTaskAsync(assignment.Id.ToString());
-            counts[assignment.Id] = attachments.Count;
-        }
-
+        var counts = await GetOrCreateAttachmentCountsAsync(
+            cache,
+            cacheKey,
+            async () => await BuildAttachmentCountsAsync(all == true, assignmentSvc, ds)
+        );
         return Results.Ok(counts);
     }
     catch (Exception ex)
@@ -720,6 +719,39 @@ static async Task<Dictionary<int, int>> GetOrCreateCommentCountsAsync(
         entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(30);
         return Task.FromResult(factory());
     });
+    return counts ?? new Dictionary<int, int>();
+}
+
+static async Task<Dictionary<int, int>> BuildAttachmentCountsAsync(
+    bool includeAll,
+    AssignmentService assignmentSvc,
+    ITaskDataSource ds)
+{
+    var assignments = includeAll
+        ? assignmentSvc.GetAllAssignments()
+        : assignmentSvc.GetUserAssignments();
+
+    var counts = new Dictionary<int, int>();
+    foreach (var assignment in assignments)
+    {
+        var attachments = await ds.GetAttachmentsForTaskAsync(assignment.Id.ToString());
+        counts[assignment.Id] = attachments.Count;
+    }
+
+    return counts;
+}
+
+static async Task<Dictionary<int, int>> GetOrCreateAttachmentCountsAsync(
+    IMemoryCache cache,
+    string cacheKey,
+    Func<Task<Dictionary<int, int>>> factory)
+{
+    var counts = await cache.GetOrCreateAsync(cacheKey, async entry =>
+    {
+        entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(30);
+        return await factory();
+    });
+
     return counts ?? new Dictionary<int, int>();
 }
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -11,6 +11,8 @@ const SORT_UNREAD_TO_TOP_KEY = "sortUnreadToTop";
 const COMMENT_SORT_NEWEST_FIRST_KEY = "commentSortNewestFirst";
 const AUTO_REFRESH_INTERVAL_SECONDS_KEY = "assignmentAutoRefreshSeconds";
 const SHOW_ALL_ASSIGNMENTS_KEY = "showAllAssignments";
+const SCOPE_MINE = "mine";
+const SCOPE_ALL = "all";
 
 function App() {
   const [assignments, setAssignments] = useState([]);
@@ -21,14 +23,20 @@ function App() {
   const [loadingComments, setLoadingComments] = useState({});
   const [openAttachments, setOpenAttachments] = useState({});
   const [attachments, setAttachments] = useState({});
-  const [attachmentCounts, setAttachmentCounts] = useState({});
+  const [attachmentCountsByScope, setAttachmentCountsByScope] = useState({
+    [SCOPE_MINE]: {},
+    [SCOPE_ALL]: {}
+  });
   const [loadingAttachments, setLoadingAttachments] = useState({});
   const [uploadingAttachment, setUploadingAttachment] = useState({});
   const [previewingAttachment, setPreviewingAttachment] = useState(false);
   const [attachmentPreview, setAttachmentPreview] = useState(null);
   const [newCommentText, setNewCommentText] = useState({});
   const [currentUser, setCurrentUser] = useState(null);
-  const [commentCounts, setCommentCounts] = useState({});
+  const [commentCountsByScope, setCommentCountsByScope] = useState({
+    [SCOPE_MINE]: {},
+    [SCOPE_ALL]: {}
+  });
   const [commentFilters, setCommentFilters] = useState({});
   const [lastSeenCommentCounts, setLastSeenCommentCounts] = useState(() => {
     try {
@@ -103,12 +111,22 @@ function App() {
   const [lastRefreshedAt, setLastRefreshedAt] = useState(null);
   const [assignmentControlsOffset, setAssignmentControlsOffset] = useState(96);
   const assignmentControlsRef = useRef(null);
-  const commentCountsRequestInFlightRef = useRef(false);
-  const attachmentCountsRequestInFlightRef = useRef(false);
+  const commentCountsRequestInFlightRef = useRef({
+    [SCOPE_MINE]: false,
+    [SCOPE_ALL]: false
+  });
+  const attachmentCountsRequestInFlightRef = useRef({
+    [SCOPE_MINE]: false,
+    [SCOPE_ALL]: false
+  });
+  const currentScopeKey = showAllAssignments ? SCOPE_ALL : SCOPE_MINE;
+  const commentCounts = commentCountsByScope[currentScopeKey] || {};
+  const attachmentCounts = attachmentCountsByScope[currentScopeKey] || {};
 
   const refreshData = useCallback(async (isInitialLoad = false) => {
     try {
       const assignmentScopeQuery = showAllAssignments ? "?all=true" : "";
+      const scopeKey = showAllAssignments ? SCOPE_ALL : SCOPE_MINE;
       const assignmentsRes = await fetch(
         `${ASSIGNMENTS_API_URL}${assignmentScopeQuery}`
       );
@@ -130,43 +148,49 @@ function App() {
         );
 
       // Keep assignment loading fast; hydrate comment counts asynchronously.
-      if (!commentCountsRequestInFlightRef.current) {
-        commentCountsRequestInFlightRef.current = true;
+      if (!commentCountsRequestInFlightRef.current[scopeKey]) {
+        commentCountsRequestInFlightRef.current[scopeKey] = true;
         fetch(
           `http://localhost:5000/api/assignments/comments/counts${assignmentScopeQuery}`
         )
           .then((res) => (res.ok ? res.json() : null))
           .then((counts) => {
             if (counts) {
-              setCommentCounts(counts);
+              setCommentCountsByScope((prev) => ({
+                ...prev,
+                [scopeKey]: counts
+              }));
             }
           })
           .catch((err) =>
             console.error("Error refreshing assignment comment counts:", err)
           )
           .finally(() => {
-            commentCountsRequestInFlightRef.current = false;
+            commentCountsRequestInFlightRef.current[scopeKey] = false;
           });
       }
 
       // Load attachment counts in the background so badges are visible
       // without opening every attachment panel.
-      if (!attachmentCountsRequestInFlightRef.current) {
-        attachmentCountsRequestInFlightRef.current = true;
+      if (!attachmentCountsRequestInFlightRef.current[scopeKey]) {
+        attachmentCountsRequestInFlightRef.current[scopeKey] = true;
         fetch(
           `http://localhost:5000/api/assignments/attachments/counts${assignmentScopeQuery}`
         )
           .then((res) => (res.ok ? res.json() : null))
           .then((counts) => {
             if (counts) {
-              setAttachmentCounts(counts);
+              setAttachmentCountsByScope((prev) => ({
+                ...prev,
+                [scopeKey]: counts
+              }));
             }
           })
           .catch((err) =>
             console.error("Error refreshing attachment counts:", err)
           )
           .finally(() => {
-            attachmentCountsRequestInFlightRef.current = false;
+            attachmentCountsRequestInFlightRef.current[scopeKey] = false;
           });
       }
 
@@ -444,9 +468,12 @@ function App() {
         const data = await response.json();
         setComments((prev) => ({ ...prev, [assignmentId]: data }));
         // Update comment count if it's different
-        setCommentCounts((prev) => ({
+        setCommentCountsByScope((prev) => ({
           ...prev,
-          [assignmentId]: data.length
+          [currentScopeKey]: {
+            ...(prev[currentScopeKey] || {}),
+            [assignmentId]: data.length
+          }
         }));
         // Load comment notes and flags for all comments
         const notesPromises = data.map((comment) =>
@@ -521,9 +548,12 @@ function App() {
       }));
       setNewCommentText((prev) => ({ ...prev, [assignmentId]: "" }));
       // Update comment count
-      setCommentCounts((prev) => ({
+      setCommentCountsByScope((prev) => ({
         ...prev,
-        [assignmentId]: nextCount
+        [currentScopeKey]: {
+          ...(prev[currentScopeKey] || {}),
+          [assignmentId]: nextCount
+        }
       }));
       // Comments authored in-app are considered seen immediately.
       setLastSeenCommentCounts((prev) => ({
@@ -551,7 +581,13 @@ function App() {
         if (!response.ok) throw new Error("Failed to fetch attachments");
         const data = await response.json();
         setAttachments((prev) => ({ ...prev, [assignmentId]: data }));
-        setAttachmentCounts((prev) => ({ ...prev, [assignmentId]: data.length }));
+        setAttachmentCountsByScope((prev) => ({
+          ...prev,
+          [currentScopeKey]: {
+            ...(prev[currentScopeKey] || {}),
+            [assignmentId]: data.length
+          }
+        }));
       } catch (err) {
         setError(err.toString());
       } finally {
@@ -586,9 +622,13 @@ function App() {
         ...prev,
         [assignmentId]: [...(prev[assignmentId] || []), uploaded]
       }));
-      setAttachmentCounts((prev) => ({
+      setAttachmentCountsByScope((prev) => ({
         ...prev,
-        [assignmentId]: (prev[assignmentId] ?? 0) + 1
+        [currentScopeKey]: {
+          ...(prev[currentScopeKey] || {}),
+          [assignmentId]:
+            ((prev[currentScopeKey] || {})[assignmentId] ?? 0) + 1
+        }
       }));
     } catch (err) {
       setError(err.toString());

--- a/client/src/components/AssignmentCard.jsx
+++ b/client/src/components/AssignmentCard.jsx
@@ -85,6 +85,12 @@ function AssignmentCard({
     total: 0,
     completed: 0
   };
+  const commentCountDisplay =
+    commentCounts[assignment.id] ?? comments?.[assignment.id]?.length ?? "…";
+  const attachmentCountDisplay =
+    attachmentCounts[assignment.id] ??
+    attachments?.[assignment.id]?.length ??
+    "…";
   const assignedToLabel =
     assignment.assignedTo && assignment.assignedTo.trim().length > 0
       ? assignment.assignedTo
@@ -155,7 +161,7 @@ function AssignmentCard({
           className="comments-button"
           onClick={() => toggleComments(assignment.id)}
         >
-          💬 {commentCounts[assignment.id] || 0}{" "}
+          💬 {commentCountDisplay}{" "}
           {openComments[assignment.id] ? "Hide" : "Comments"}
           {checklistSummary.total > 0 && (
             <span className="comments-checklist-summary">
@@ -178,10 +184,7 @@ function AssignmentCard({
           className="attachments-button"
           onClick={() => toggleAttachments(assignment.id)}
         >
-          📎{" "}
-          {attachmentCounts[assignment.id] ??
-            attachments[assignment.id]?.length ??
-            0}{" "}
+          📎 {attachmentCountDisplay}{" "}
           {openAttachments[assignment.id] ? "Hide" : "Attachments"}
         </button>
         {assignment.status !== 2 && (


### PR DESCRIPTION
## Summary
- make comment and attachment count requests scope-aware (`mine` vs `all`) so Team and Mine refreshes do not block each other
- avoid misleading `0` badges while counts are still loading by showing a neutral loading placeholder and using loaded panel data when available
- add 30s cache for attachment count endpoint and invalidate it on upload to improve Team refresh consistency

## Test plan
- [x] Build backend: `dotnet build`
- [x] Build frontend: `npm run build`
- [x] Verify API starts and serves counts endpoints
- [ ] In UI, switch between Mine and Team repeatedly and confirm badges continue updating
- [ ] Confirm unknown/loading badges resolve to correct counts without opening every panel
- [ ] Upload an attachment and verify attachment badge updates after refresh

Closes #74

Made with [Cursor](https://cursor.com)