### PR TITLE
feat(local-data): add local audit timestamps and fix comment checklist scope

### DIFF
--- a/backend/src/Taskify.Api/Program.cs
+++ b/backend/src/Taskify.Api/Program.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Caching.Memory;
 
 
 var builder = WebApplication.CreateBuilder(args);
+var localStorageDirectory = ResolveLocalStorageDirectory(builder.Configuration, builder.Environment.ContentRootPath);
 
 // Logging
 builder.Services.AddLogging(logging =>
@@ -42,14 +43,14 @@ builder.Services.AddSingleton<ITaskDataSource>(sp =>
 });
 
 // ── Local Storage (Taskify-owned data: subtasks, notes, flags, board) ──
-builder.Services.AddSingleton<SubtaskStore>();
-builder.Services.AddSingleton<SubtaskNoteStore>();
-builder.Services.AddSingleton<CommentNoteStore>();
-builder.Services.AddSingleton<CommentFlagStore>();
-builder.Services.AddSingleton<CommentSubtaskStore>();
-builder.Services.AddSingleton<QuickTaskStore>();
-builder.Services.AddSingleton<AssignmentBoardStore>();
-builder.Services.AddSingleton<WorkingOnStore>();
+builder.Services.AddSingleton(new SubtaskStore(localStorageDirectory));
+builder.Services.AddSingleton(new SubtaskNoteStore(localStorageDirectory));
+builder.Services.AddSingleton(new CommentNoteStore(localStorageDirectory));
+builder.Services.AddSingleton(new CommentFlagStore(localStorageDirectory));
+builder.Services.AddSingleton(new CommentSubtaskStore(localStorageDirectory));
+builder.Services.AddSingleton(new QuickTaskStore(localStorageDirectory));
+builder.Services.AddSingleton(new AssignmentBoardStore(localStorageDirectory));
+builder.Services.AddSingleton(new WorkingOnStore(localStorageDirectory));
 
 // ── Repositories ──
 builder.Services.AddScoped<ISubtaskRepository, LocalSubtaskRepository>();
@@ -258,8 +259,13 @@ app.MapPost("api/assignments/{id:int}/comments", async (int id, CommentService s
 });
 app.MapGet("api/comments/{id:int}/note", (int id, CommentNoteService svc) =>
 {
-    var note = svc.GetCommentNote(id);
-    return Results.Ok(new { note });
+    var note = svc.GetCommentNoteItem(id);
+    return Results.Ok(new
+    {
+        note = note?.Note,
+        createdDate = note?.CreatedDate,
+        updatedDate = note?.UpdatedDate
+    });
 });
 app.MapPut("api/comments/{id:int}/note", async (int id, CommentNoteService svc, HttpRequest req) =>
 {
@@ -268,13 +274,28 @@ app.MapPut("api/comments/{id:int}/note", async (int id, CommentNoteService svc, 
         return Results.BadRequest("body required");
     try
     {
-        svc.UpdateCommentNote(id, body.Note);
-        return Results.Ok();
+        var updated = svc.UpdateCommentNote(id, body.Note);
+        return Results.Ok(new
+        {
+            note = updated?.Note,
+            createdDate = updated?.CreatedDate,
+            updatedDate = updated?.UpdatedDate
+        });
     }
     catch (ArgumentException ex)
     {
         return Results.BadRequest(ex.Message);
     }
+});
+app.MapGet("api/subtasks/{id:int}/note", (int id, SubtaskNoteStore store) =>
+{
+    var note = store.GetNoteItem(id);
+    return Results.Ok(new
+    {
+        note = note?.Note,
+        createdDate = note?.CreatedDate,
+        updatedDate = note?.UpdatedDate
+    });
 });
 app.MapGet("api/comments/{id:int}/flag", (int id, CommentFlagService svc) =>
 {
@@ -289,11 +310,11 @@ app.MapPut("api/comments/{id:int}/flag", async (int id, CommentFlagService svc, 
     svc.SetCommentFlag(id, body.IsFlagged);
     return Results.Ok();
 });
-app.MapGet("api/comments/{id:int}/subtasks", (int id, CommentSubtaskService svc) =>
+app.MapGet("api/assignments/{assignmentId:int}/comments/{id:int}/subtasks", (int assignmentId, int id, CommentSubtaskService svc) =>
 {
     try
     {
-        var subtasks = svc.GetCommentSubtasks(id);
+        var subtasks = svc.GetCommentSubtasks(assignmentId, id);
         return Results.Ok(subtasks);
     }
     catch (ArgumentException ex)
@@ -301,7 +322,7 @@ app.MapGet("api/comments/{id:int}/subtasks", (int id, CommentSubtaskService svc)
         return Results.BadRequest(ex.Message);
     }
 });
-app.MapPost("api/comments/{id:int}/subtasks", async (int id, CommentSubtaskService svc, HttpRequest req) =>
+app.MapPost("api/assignments/{assignmentId:int}/comments/{id:int}/subtasks", async (int assignmentId, int id, CommentSubtaskService svc, HttpRequest req) =>
 {
     var body = await req.ReadFromJsonAsync<AddCommentSubtaskRequest>();
     if (body == null || string.IsNullOrWhiteSpace(body.Title))
@@ -309,7 +330,7 @@ app.MapPost("api/comments/{id:int}/subtasks", async (int id, CommentSubtaskServi
 
     try
     {
-        var subtask = svc.AddCommentSubtask(id, body.Title, body.Order);
+        var subtask = svc.AddCommentSubtask(assignmentId, id, body.Title, body.Order);
         return Results.Ok(subtask);
     }
     catch (ArgumentException ex)
@@ -349,7 +370,7 @@ app.MapPut("api/comments/subtasks/{id:int}/title", async (int id, CommentSubtask
         return Results.BadRequest(ex.Message);
     }
 });
-app.MapPut("api/comments/{id:int}/subtasks/reorder", async (int id, CommentSubtaskService svc, HttpRequest req) =>
+app.MapPut("api/assignments/{assignmentId:int}/comments/{id:int}/subtasks/reorder", async (int assignmentId, int id, CommentSubtaskService svc, HttpRequest req) =>
 {
     var body = await req.ReadFromJsonAsync<ReorderCommentSubtasksRequest>();
     if (body == null || body.SubtaskOrders == null || body.SubtaskOrders.Count == 0)
@@ -357,7 +378,7 @@ app.MapPut("api/comments/{id:int}/subtasks/reorder", async (int id, CommentSubta
 
     try
     {
-        svc.ReorderCommentSubtasks(id, body.SubtaskOrders);
+        svc.ReorderCommentSubtasks(assignmentId, id, body.SubtaskOrders);
         return Results.Ok();
     }
     catch (ArgumentException ex)
@@ -753,6 +774,42 @@ static async Task<Dictionary<int, int>> GetOrCreateAttachmentCountsAsync(
     });
 
     return counts ?? new Dictionary<int, int>();
+}
+
+static string ResolveLocalStorageDirectory(IConfiguration configuration, string contentRootPath)
+{
+    // Optional override in appsettings: "Taskify:LocalStorageDirectory"
+    var configuredPath = configuration["Taskify:LocalStorageDirectory"];
+    if (!string.IsNullOrWhiteSpace(configuredPath))
+    {
+        return Path.IsPathRooted(configuredPath)
+            ? configuredPath
+            : Path.GetFullPath(Path.Combine(contentRootPath, configuredPath));
+    }
+
+    // Try known historical locations first to avoid switching datasets
+    // between dotnet run and published dll executions.
+    var candidateDirectories = new[]
+    {
+        Path.Combine(contentRootPath, "publish", "api", "storage"),
+        Path.GetFullPath(Path.Combine(contentRootPath, "..", "publish", "api", "storage")),
+        Path.GetFullPath(Path.Combine(contentRootPath, "..", "..", "publish", "api", "storage")),
+        Path.Combine(contentRootPath, "storage"),
+        Path.GetFullPath(Path.Combine(contentRootPath, "..", "storage")),
+        Path.GetFullPath(Path.Combine(contentRootPath, "..", "..", "storage"))
+    }
+    .Distinct(StringComparer.OrdinalIgnoreCase)
+    .ToList();
+
+    foreach (var candidate in candidateDirectories)
+    {
+        if (Directory.Exists(candidate))
+        {
+            return candidate;
+        }
+    }
+
+    return Path.Combine(contentRootPath, "storage");
 }
 
 public record AddCommentRequest(string Content);

--- a/backend/src/Taskify.Domain/Entities/Subtask.cs
+++ b/backend/src/Taskify.Domain/Entities/Subtask.cs
@@ -9,6 +9,7 @@ public class Subtask
     public int Order { get; private set; }
     public DateTime CreatedDate { get; private set; }
     public DateTime? CompletedDate { get; private set; }
+    public DateTime UpdatedDate { get; private set; }
     public string? PersonalNote { get; private set; }
 
     public Subtask(
@@ -19,6 +20,7 @@ public class Subtask
         int order,
         DateTime createdDate,
         DateTime? completedDate = null,
+        DateTime? updatedDate = null,
         string? personalNote = null)
     {
         if (id <= 0)
@@ -43,6 +45,7 @@ public class Subtask
         Order = order;
         CreatedDate = createdDate;
         CompletedDate = completedDate;
+        UpdatedDate = updatedDate ?? createdDate;
         PersonalNote = personalNote;
     }
 

--- a/backend/src/Taskify.Infrastructure/Storage/CommentNoteService.cs
+++ b/backend/src/Taskify.Infrastructure/Storage/CommentNoteService.cs
@@ -16,18 +16,24 @@ public class CommentNoteService
         return _noteStore.GetNote(commentId);
     }
 
-    public void UpdateCommentNote(int commentId, string? note)
+    public CommentNoteItem? GetCommentNoteItem(int commentId)
+    {
+        return _noteStore.GetNoteItem(commentId);
+    }
+
+    public CommentNoteItem? UpdateCommentNote(int commentId, string? note)
     {
         if (string.IsNullOrWhiteSpace(note))
         {
             _noteStore.DeleteNote(commentId);
+            return null;
         }
         else
         {
             if (note.Length > 1000)
                 throw new ArgumentException("Comment note cannot exceed 1000 characters");
             
-            _noteStore.SaveNote(commentId, note);
+            return _noteStore.SaveNote(commentId, note);
         }
     }
 }

--- a/backend/src/Taskify.Infrastructure/Storage/CommentNoteStore.cs
+++ b/backend/src/Taskify.Infrastructure/Storage/CommentNoteStore.cs
@@ -5,7 +5,7 @@ namespace Taskify.Infrastructure.Storage;
 public class CommentNoteStore
 {
     private readonly string _storageFilePath;
-    private Dictionary<int, string> _notes;
+    private Dictionary<int, CommentNoteItem> _notes;
 
     public CommentNoteStore(string storageDirectory = "storage")
     {
@@ -24,10 +24,26 @@ public class CommentNoteStore
         _notes = LoadNotes();
     }
 
-    public void SaveNote(int commentId, string note)
+    public CommentNoteItem SaveNote(int commentId, string note)
     {
-        _notes[commentId] = note;
+        var now = DateTime.UtcNow;
+        if (_notes.TryGetValue(commentId, out var existing))
+        {
+            existing.Note = note;
+            existing.UpdatedDate = now;
+            _notes[commentId] = existing;
+        }
+        else
+        {
+            _notes[commentId] = new CommentNoteItem
+            {
+                Note = note,
+                CreatedDate = now,
+                UpdatedDate = now
+            };
+        }
         PersistNotes();
+        return _notes[commentId];
     }
 
     public void DeleteNote(int commentId)
@@ -38,23 +54,63 @@ public class CommentNoteStore
 
     public string? GetNote(int commentId)
     {
-        return _notes.TryGetValue(commentId, out var note) ? note : null;
+        return _notes.TryGetValue(commentId, out var note) ? note.Note : null;
+    }
+
+    public CommentNoteItem? GetNoteItem(int commentId)
+    {
+        return _notes.TryGetValue(commentId, out var note)
+            ? new CommentNoteItem
+            {
+                Note = note.Note,
+                CreatedDate = note.CreatedDate,
+                UpdatedDate = note.UpdatedDate
+            }
+            : null;
     }
 
     public Dictionary<int, string> GetAllNotes()
     {
-        return new Dictionary<int, string>(_notes);
+        return _notes.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Note);
     }
 
-    private Dictionary<int, string> LoadNotes()
+    private Dictionary<int, CommentNoteItem> LoadNotes()
     {
         try
         {
             if (File.Exists(_storageFilePath))
             {
                 var json = File.ReadAllText(_storageFilePath);
-                return JsonSerializer.Deserialize<Dictionary<int, string>>(json)
-                    ?? new Dictionary<int, string>();
+                var rawMap = JsonSerializer.Deserialize<Dictionary<int, JsonElement>>(json);
+                if (rawMap != null)
+                {
+                    var mapped = new Dictionary<int, CommentNoteItem>();
+                    var now = DateTime.UtcNow;
+                    foreach (var kvp in rawMap)
+                    {
+                        if (kvp.Value.ValueKind == JsonValueKind.String)
+                        {
+                            mapped[kvp.Key] = new CommentNoteItem
+                            {
+                                Note = kvp.Value.GetString() ?? string.Empty,
+                                CreatedDate = now,
+                                UpdatedDate = now
+                            };
+                            continue;
+                        }
+
+                        if (kvp.Value.ValueKind == JsonValueKind.Object)
+                        {
+                            var item = kvp.Value.Deserialize<CommentNoteItem>() ?? new CommentNoteItem();
+                            if (item.CreatedDate == default)
+                                item.CreatedDate = now;
+                            if (item.UpdatedDate == default)
+                                item.UpdatedDate = item.CreatedDate;
+                            mapped[kvp.Key] = item;
+                        }
+                    }
+                    return mapped;
+                }
             }
         }
         catch (Exception ex)
@@ -62,7 +118,7 @@ public class CommentNoteStore
             Console.WriteLine($"Warning: Failed to load comment notes: {ex.Message}");
         }
 
-        return new Dictionary<int, string>();
+        return new Dictionary<int, CommentNoteItem>();
     }
 
     private void PersistNotes()
@@ -80,5 +136,12 @@ public class CommentNoteStore
             Console.WriteLine($"Warning: Failed to persist comment notes: {ex.Message}");
         }
     }
+}
+
+public class CommentNoteItem
+{
+    public string Note { get; set; } = string.Empty;
+    public DateTime CreatedDate { get; set; }
+    public DateTime UpdatedDate { get; set; }
 }
 

--- a/backend/src/Taskify.Infrastructure/Storage/CommentSubtaskService.cs
+++ b/backend/src/Taskify.Infrastructure/Storage/CommentSubtaskService.cs
@@ -9,16 +9,20 @@ public class CommentSubtaskService
         _store = store;
     }
 
-    public List<CommentSubtaskItem> GetCommentSubtasks(int commentId)
+    public List<CommentSubtaskItem> GetCommentSubtasks(int assignmentId, int commentId)
     {
+        if (assignmentId <= 0)
+            throw new ArgumentException("Assignment ID must be positive", nameof(assignmentId));
         if (commentId <= 0)
             throw new ArgumentException("Comment ID must be positive", nameof(commentId));
 
-        return _store.GetSubtasksForComment(commentId);
+        return _store.GetSubtasksForComment(assignmentId, commentId);
     }
 
-    public CommentSubtaskItem AddCommentSubtask(int commentId, string title, int? order = null)
+    public CommentSubtaskItem AddCommentSubtask(int assignmentId, int commentId, string title, int? order = null)
     {
+        if (assignmentId <= 0)
+            throw new ArgumentException("Assignment ID must be positive", nameof(assignmentId));
         if (commentId <= 0)
             throw new ArgumentException("Comment ID must be positive", nameof(commentId));
         if (string.IsNullOrWhiteSpace(title))
@@ -28,7 +32,7 @@ public class CommentSubtaskService
         if (trimmed.Length > 200)
             throw new ArgumentException("Subtask title cannot exceed 200 characters", nameof(title));
 
-        return _store.AddSubtask(commentId, trimmed, order);
+        return _store.AddSubtask(assignmentId, commentId, trimmed, order);
     }
 
     public bool ToggleCommentSubtaskCompletion(int subtaskId, bool isCompleted)
@@ -61,13 +65,15 @@ public class CommentSubtaskService
         return _store.DeleteSubtask(subtaskId);
     }
 
-    public void ReorderCommentSubtasks(int commentId, Dictionary<int, int> subtaskIdToOrder)
+    public void ReorderCommentSubtasks(int assignmentId, int commentId, Dictionary<int, int> subtaskIdToOrder)
     {
+        if (assignmentId <= 0)
+            throw new ArgumentException("Assignment ID must be positive", nameof(assignmentId));
         if (commentId <= 0)
             throw new ArgumentException("Comment ID must be positive", nameof(commentId));
         if (subtaskIdToOrder == null || subtaskIdToOrder.Count == 0)
             throw new ArgumentException("Subtask order mapping cannot be empty", nameof(subtaskIdToOrder));
 
-        _store.ReorderSubtasks(commentId, subtaskIdToOrder);
+        _store.ReorderSubtasks(assignmentId, commentId, subtaskIdToOrder);
     }
 }

--- a/backend/src/Taskify.Infrastructure/Storage/CommentSubtaskStore.cs
+++ b/backend/src/Taskify.Infrastructure/Storage/CommentSubtaskStore.cs
@@ -4,6 +4,7 @@ namespace Taskify.Infrastructure.Storage;
 
 public class CommentSubtaskStore
 {
+    private const string LegacyScopePrefix = "legacy:";
     private readonly string _storageFilePath;
     private readonly object _syncRoot = new();
     private CommentSubtaskStoreModel _model;
@@ -20,11 +21,18 @@ public class CommentSubtaskStore
         _model = Load();
     }
 
-    public List<CommentSubtaskItem> GetSubtasksForComment(int commentId)
+    public List<CommentSubtaskItem> GetSubtasksForComment(int assignmentId, int commentId)
     {
         lock (_syncRoot)
         {
-            if (!_model.CommentIdToSubtasks.TryGetValue(commentId, out var items))
+            var scopeKey = BuildScopeKey(assignmentId, commentId);
+            if (!_model.CommentScopeToSubtasks.TryGetValue(scopeKey, out var items))
+            {
+                var legacyScopeKey = BuildLegacyScopeKey(commentId);
+                _model.CommentScopeToSubtasks.TryGetValue(legacyScopeKey, out items);
+            }
+
+            if (items == null)
                 return new List<CommentSubtaskItem>();
 
             return items
@@ -32,24 +40,30 @@ public class CommentSubtaskStore
                 .Select(i => new CommentSubtaskItem
                 {
                     Id = i.Id,
+                    AssignmentId = assignmentId,
                     CommentId = commentId,
                     Title = i.Title,
                     IsCompleted = i.IsCompleted,
                     Order = i.Order,
                     CreatedDate = i.CreatedDate,
-                    CompletedDate = i.CompletedDate
+                    CompletedDate = i.CompletedDate,
+                    UpdatedDate = i.UpdatedDate
                 })
                 .ToList();
         }
     }
 
-    public CommentSubtaskItem AddSubtask(int commentId, string title, int? order = null)
+    public CommentSubtaskItem AddSubtask(int assignmentId, int commentId, string title, int? order = null)
     {
         lock (_syncRoot)
         {
             var id = _model.NextId++;
             var now = DateTime.UtcNow;
-            var list = _model.CommentIdToSubtasks.GetValueOrDefault(commentId) ?? new List<CommentSubtaskItemModel>();
+            var scopeKey = BuildScopeKey(assignmentId, commentId);
+            var legacyScopeKey = BuildLegacyScopeKey(commentId);
+            var list = _model.CommentScopeToSubtasks.GetValueOrDefault(scopeKey)
+                ?? _model.CommentScopeToSubtasks.GetValueOrDefault(legacyScopeKey)
+                ?? new List<CommentSubtaskItemModel>();
             var newOrder = order ?? (list.Count == 0 ? 0 : list.Max(i => i.Order) + 1);
 
             var item = new CommentSubtaskItemModel
@@ -58,11 +72,14 @@ public class CommentSubtaskStore
                 Title = title,
                 IsCompleted = false,
                 Order = newOrder,
-                CreatedDate = now
+                CreatedDate = now,
+                UpdatedDate = now
             };
 
-            if (!_model.CommentIdToSubtasks.ContainsKey(commentId))
-                _model.CommentIdToSubtasks[commentId] = list;
+            if (!_model.CommentScopeToSubtasks.ContainsKey(scopeKey))
+                _model.CommentScopeToSubtasks[scopeKey] = list;
+            if (_model.CommentScopeToSubtasks.ContainsKey(legacyScopeKey))
+                _model.CommentScopeToSubtasks.Remove(legacyScopeKey);
 
             list.Add(item);
             Persist();
@@ -70,11 +87,13 @@ public class CommentSubtaskStore
             return new CommentSubtaskItem
             {
                 Id = id,
+                AssignmentId = assignmentId,
                 CommentId = commentId,
                 Title = title,
                 IsCompleted = false,
                 Order = newOrder,
-                CreatedDate = now
+                CreatedDate = now,
+                UpdatedDate = now
             };
         }
     }
@@ -83,7 +102,7 @@ public class CommentSubtaskStore
     {
         lock (_syncRoot)
         {
-            foreach (var kvp in _model.CommentIdToSubtasks)
+            foreach (var kvp in _model.CommentScopeToSubtasks)
             {
                 var item = kvp.Value.FirstOrDefault(i => i.Id == subtaskId);
                 if (item == null)
@@ -91,6 +110,7 @@ public class CommentSubtaskStore
 
                 item.IsCompleted = isCompleted;
                 item.CompletedDate = isCompleted ? DateTime.UtcNow : null;
+                item.UpdatedDate = DateTime.UtcNow;
                 Persist();
                 return true;
             }
@@ -103,13 +123,14 @@ public class CommentSubtaskStore
     {
         lock (_syncRoot)
         {
-            foreach (var kvp in _model.CommentIdToSubtasks)
+            foreach (var kvp in _model.CommentScopeToSubtasks)
             {
                 var item = kvp.Value.FirstOrDefault(i => i.Id == subtaskId);
                 if (item == null)
                     continue;
 
                 item.Title = title;
+                item.UpdatedDate = DateTime.UtcNow;
                 Persist();
                 return true;
             }
@@ -118,18 +139,33 @@ public class CommentSubtaskStore
         }
     }
 
-    public bool ReorderSubtasks(int commentId, Dictionary<int, int> subtaskIdToOrder)
+    public bool ReorderSubtasks(int assignmentId, int commentId, Dictionary<int, int> subtaskIdToOrder)
     {
         lock (_syncRoot)
         {
-            if (!_model.CommentIdToSubtasks.TryGetValue(commentId, out var items))
+            var scopeKey = BuildScopeKey(assignmentId, commentId);
+            if (!_model.CommentScopeToSubtasks.TryGetValue(scopeKey, out var items))
+            {
+                var legacyScopeKey = BuildLegacyScopeKey(commentId);
+                if (_model.CommentScopeToSubtasks.TryGetValue(legacyScopeKey, out var legacyItems))
+                {
+                    items = legacyItems;
+                    _model.CommentScopeToSubtasks[scopeKey] = items;
+                    _model.CommentScopeToSubtasks.Remove(legacyScopeKey);
+                }
+            }
+
+            if (items == null)
                 return false;
 
             foreach (var kvp in subtaskIdToOrder)
             {
                 var item = items.FirstOrDefault(i => i.Id == kvp.Key);
                 if (item != null)
+                {
                     item.Order = kvp.Value;
+                    item.UpdatedDate = DateTime.UtcNow;
+                }
             }
 
             Persist();
@@ -141,7 +177,7 @@ public class CommentSubtaskStore
     {
         lock (_syncRoot)
         {
-            foreach (var kvp in _model.CommentIdToSubtasks)
+            foreach (var kvp in _model.CommentScopeToSubtasks)
             {
                 var item = kvp.Value.FirstOrDefault(i => i.Id == subtaskId);
                 if (item == null)
@@ -163,12 +199,38 @@ public class CommentSubtaskStore
             if (File.Exists(_storageFilePath))
             {
                 var json = File.ReadAllText(_storageFilePath);
-                var loaded = JsonSerializer.Deserialize<CommentSubtaskStoreModel>(json);
-                if (loaded != null)
+                using var document = JsonDocument.Parse(json);
+                var root = document.RootElement;
+                var loaded = new CommentSubtaskStoreModel();
+                if (root.TryGetProperty("NextId", out var nextIdElement) &&
+                    nextIdElement.ValueKind == JsonValueKind.Number)
                 {
-                    loaded.CommentIdToSubtasks ??= new Dictionary<int, List<CommentSubtaskItemModel>>();
-                    return loaded;
+                    loaded.NextId = nextIdElement.GetInt32();
                 }
+
+                if (root.TryGetProperty("CommentScopeToSubtasks", out var scopedElement) &&
+                    scopedElement.ValueKind == JsonValueKind.Object)
+                {
+                    loaded.CommentScopeToSubtasks = DeserializeScopedMap(scopedElement);
+                }
+                else if (root.TryGetProperty("CommentIdToSubtasks", out var legacyElement) &&
+                    legacyElement.ValueKind == JsonValueKind.Object)
+                {
+                    loaded.CommentScopeToSubtasks = DeserializeLegacyMap(legacyElement);
+                }
+
+                foreach (var items in loaded.CommentScopeToSubtasks.Values)
+                {
+                    foreach (var item in items)
+                    {
+                        if (item.CreatedDate == default)
+                            item.CreatedDate = DateTime.UtcNow;
+                        if (item.UpdatedDate == default)
+                            item.UpdatedDate = item.CreatedDate;
+                    }
+                }
+
+                return loaded;
             }
         }
         catch (Exception ex)
@@ -179,7 +241,7 @@ public class CommentSubtaskStore
         return new CommentSubtaskStoreModel
         {
             NextId = 1,
-            CommentIdToSubtasks = new Dictionary<int, List<CommentSubtaskItemModel>>()
+            CommentScopeToSubtasks = new Dictionary<string, List<CommentSubtaskItemModel>>()
         };
     }
 
@@ -199,7 +261,7 @@ public class CommentSubtaskStore
     private class CommentSubtaskStoreModel
     {
         public int NextId { get; set; }
-        public Dictionary<int, List<CommentSubtaskItemModel>> CommentIdToSubtasks { get; set; } = new();
+        public Dictionary<string, List<CommentSubtaskItemModel>> CommentScopeToSubtasks { get; set; } = new();
     }
 
     private class CommentSubtaskItemModel
@@ -210,16 +272,50 @@ public class CommentSubtaskStore
         public int Order { get; set; }
         public DateTime CreatedDate { get; set; }
         public DateTime? CompletedDate { get; set; }
+        public DateTime UpdatedDate { get; set; }
+    }
+
+    private static string BuildScopeKey(int assignmentId, int commentId) =>
+        $"{assignmentId}:{commentId}";
+
+    private static string BuildLegacyScopeKey(int commentId) =>
+        $"{LegacyScopePrefix}{commentId}";
+
+    private static Dictionary<string, List<CommentSubtaskItemModel>> DeserializeScopedMap(JsonElement scopedElement)
+    {
+        var result = new Dictionary<string, List<CommentSubtaskItemModel>>();
+        foreach (var property in scopedElement.EnumerateObject())
+        {
+            var list = property.Value.Deserialize<List<CommentSubtaskItemModel>>() ?? new List<CommentSubtaskItemModel>();
+            result[property.Name] = list;
+        }
+        return result;
+    }
+
+    private static Dictionary<string, List<CommentSubtaskItemModel>> DeserializeLegacyMap(JsonElement legacyElement)
+    {
+        var result = new Dictionary<string, List<CommentSubtaskItemModel>>();
+        foreach (var property in legacyElement.EnumerateObject())
+        {
+            if (!int.TryParse(property.Name, out var commentId))
+                continue;
+
+            var list = property.Value.Deserialize<List<CommentSubtaskItemModel>>() ?? new List<CommentSubtaskItemModel>();
+            result[BuildLegacyScopeKey(commentId)] = list;
+        }
+        return result;
     }
 }
 
 public class CommentSubtaskItem
 {
     public int Id { get; set; }
+    public int AssignmentId { get; set; }
     public int CommentId { get; set; }
     public string Title { get; set; } = string.Empty;
     public bool IsCompleted { get; set; }
     public int Order { get; set; }
     public DateTime CreatedDate { get; set; }
     public DateTime? CompletedDate { get; set; }
+    public DateTime UpdatedDate { get; set; }
 }

--- a/backend/src/Taskify.Infrastructure/Storage/QuickTaskStore.cs
+++ b/backend/src/Taskify.Infrastructure/Storage/QuickTaskStore.cs
@@ -42,7 +42,8 @@ public class QuickTaskStore
                 Id = _model.NextTaskId++,
                 Title = title,
                 IsCompleted = false,
-                CreatedDate = now
+                CreatedDate = now,
+                UpdatedDate = now
             };
             _model.Tasks.Add(task);
             Persist();
@@ -59,6 +60,7 @@ public class QuickTaskStore
                 return false;
 
             task.Title = title;
+            task.UpdatedDate = DateTime.UtcNow;
             Persist();
             return true;
         }
@@ -74,6 +76,7 @@ public class QuickTaskStore
 
             task.IsCompleted = isCompleted;
             task.CompletedDate = isCompleted ? DateTime.UtcNow : null;
+            task.UpdatedDate = DateTime.UtcNow;
             Persist();
             return true;
         }
@@ -108,7 +111,8 @@ public class QuickTaskStore
                     Id = c.Id,
                     TaskId = taskId,
                     Content = c.Content,
-                    CreatedDate = c.CreatedDate
+                    CreatedDate = c.CreatedDate,
+                    UpdatedDate = c.UpdatedDate
                 })
                 .ToList();
         }
@@ -126,9 +130,11 @@ public class QuickTaskStore
             {
                 Id = _model.NextCommentId++,
                 Content = content,
-                CreatedDate = DateTime.UtcNow
+                CreatedDate = DateTime.UtcNow,
+                UpdatedDate = DateTime.UtcNow
             };
             task.Comments.Add(comment);
+            task.UpdatedDate = DateTime.UtcNow;
             Persist();
 
             return new QuickTaskCommentItem
@@ -136,7 +142,8 @@ public class QuickTaskStore
                 Id = comment.Id,
                 TaskId = taskId,
                 Content = comment.Content,
-                CreatedDate = comment.CreatedDate
+                CreatedDate = comment.CreatedDate,
+                UpdatedDate = comment.UpdatedDate
             };
         }
     }
@@ -152,6 +159,8 @@ public class QuickTaskStore
                     continue;
 
                 comment.Content = content;
+                comment.UpdatedDate = DateTime.UtcNow;
+                task.UpdatedDate = DateTime.UtcNow;
                 Persist();
                 return true;
             }
@@ -171,6 +180,7 @@ public class QuickTaskStore
                     continue;
 
                 task.Comments.Remove(comment);
+                task.UpdatedDate = DateTime.UtcNow;
                 Persist();
                 return true;
             }
@@ -197,7 +207,8 @@ public class QuickTaskStore
                     IsCompleted = i.IsCompleted,
                     Order = i.Order,
                     CreatedDate = i.CreatedDate,
-                    CompletedDate = i.CompletedDate
+                    CompletedDate = i.CompletedDate,
+                    UpdatedDate = i.UpdatedDate
                 })
                 .ToList();
         }
@@ -218,10 +229,12 @@ public class QuickTaskStore
                 Title = title,
                 IsCompleted = false,
                 Order = newOrder,
-                CreatedDate = DateTime.UtcNow
+                CreatedDate = DateTime.UtcNow,
+                UpdatedDate = DateTime.UtcNow
             };
 
             task.Checklist.Add(item);
+            task.UpdatedDate = DateTime.UtcNow;
             Persist();
 
             return new QuickTaskChecklistItem
@@ -231,7 +244,8 @@ public class QuickTaskStore
                 Title = item.Title,
                 IsCompleted = item.IsCompleted,
                 Order = item.Order,
-                CreatedDate = item.CreatedDate
+                CreatedDate = item.CreatedDate,
+                UpdatedDate = item.UpdatedDate
             };
         }
     }
@@ -248,6 +262,8 @@ public class QuickTaskStore
 
                 item.IsCompleted = isCompleted;
                 item.CompletedDate = isCompleted ? DateTime.UtcNow : null;
+                item.UpdatedDate = DateTime.UtcNow;
+                task.UpdatedDate = DateTime.UtcNow;
                 Persist();
                 return true;
             }
@@ -267,6 +283,8 @@ public class QuickTaskStore
                     continue;
 
                 item.Title = title;
+                item.UpdatedDate = DateTime.UtcNow;
+                task.UpdatedDate = DateTime.UtcNow;
                 Persist();
                 return true;
             }
@@ -287,9 +305,13 @@ public class QuickTaskStore
             {
                 var item = task.Checklist.FirstOrDefault(i => i.Id == kvp.Key);
                 if (item != null)
+                {
                     item.Order = kvp.Value;
+                    item.UpdatedDate = DateTime.UtcNow;
+                }
             }
 
+            task.UpdatedDate = DateTime.UtcNow;
             Persist();
             return true;
         }
@@ -306,6 +328,7 @@ public class QuickTaskStore
                     continue;
 
                 task.Checklist.Remove(item);
+                task.UpdatedDate = DateTime.UtcNow;
                 Persist();
                 return true;
             }
@@ -323,6 +346,7 @@ public class QuickTaskStore
             IsCompleted = model.IsCompleted,
             CreatedDate = model.CreatedDate,
             CompletedDate = model.CompletedDate,
+            UpdatedDate = model.UpdatedDate,
             Comments = model.Comments
                 .OrderBy(c => c.CreatedDate)
                 .Select(c => new QuickTaskCommentItem
@@ -330,7 +354,8 @@ public class QuickTaskStore
                     Id = c.Id,
                     TaskId = model.Id,
                     Content = c.Content,
-                    CreatedDate = c.CreatedDate
+                    CreatedDate = c.CreatedDate,
+                    UpdatedDate = c.UpdatedDate
                 })
                 .ToList(),
             Checklist = model.Checklist
@@ -343,7 +368,8 @@ public class QuickTaskStore
                     IsCompleted = i.IsCompleted,
                     Order = i.Order,
                     CreatedDate = i.CreatedDate,
-                    CompletedDate = i.CompletedDate
+                    CompletedDate = i.CompletedDate,
+                    UpdatedDate = i.UpdatedDate
                 })
                 .ToList()
         };
@@ -362,8 +388,26 @@ public class QuickTaskStore
                     loaded.Tasks ??= new List<QuickTaskModel>();
                     foreach (var task in loaded.Tasks)
                     {
+                        if (task.CreatedDate == default)
+                            task.CreatedDate = DateTime.UtcNow;
+                        if (task.UpdatedDate == default)
+                            task.UpdatedDate = task.CreatedDate;
                         task.Comments ??= new List<QuickTaskCommentModel>();
+                        foreach (var comment in task.Comments)
+                        {
+                            if (comment.CreatedDate == default)
+                                comment.CreatedDate = task.CreatedDate;
+                            if (comment.UpdatedDate == default)
+                                comment.UpdatedDate = comment.CreatedDate;
+                        }
                         task.Checklist ??= new List<QuickTaskChecklistItemModel>();
+                        foreach (var checklistItem in task.Checklist)
+                        {
+                            if (checklistItem.CreatedDate == default)
+                                checklistItem.CreatedDate = task.CreatedDate;
+                            if (checklistItem.UpdatedDate == default)
+                                checklistItem.UpdatedDate = checklistItem.CreatedDate;
+                        }
                     }
                     return loaded;
                 }
@@ -411,6 +455,7 @@ public class QuickTaskStore
         public bool IsCompleted { get; set; }
         public DateTime CreatedDate { get; set; }
         public DateTime? CompletedDate { get; set; }
+        public DateTime UpdatedDate { get; set; }
         public List<QuickTaskCommentModel> Comments { get; set; } = new();
         public List<QuickTaskChecklistItemModel> Checklist { get; set; } = new();
     }
@@ -420,6 +465,7 @@ public class QuickTaskStore
         public int Id { get; set; }
         public string Content { get; set; } = string.Empty;
         public DateTime CreatedDate { get; set; }
+        public DateTime UpdatedDate { get; set; }
     }
 
     private class QuickTaskChecklistItemModel
@@ -430,6 +476,7 @@ public class QuickTaskStore
         public int Order { get; set; }
         public DateTime CreatedDate { get; set; }
         public DateTime? CompletedDate { get; set; }
+        public DateTime UpdatedDate { get; set; }
     }
 }
 
@@ -440,6 +487,7 @@ public class QuickTaskItem
     public bool IsCompleted { get; set; }
     public DateTime CreatedDate { get; set; }
     public DateTime? CompletedDate { get; set; }
+    public DateTime UpdatedDate { get; set; }
     public List<QuickTaskCommentItem> Comments { get; set; } = new();
     public List<QuickTaskChecklistItem> Checklist { get; set; } = new();
 }
@@ -450,6 +498,7 @@ public class QuickTaskCommentItem
     public int TaskId { get; set; }
     public string Content { get; set; } = string.Empty;
     public DateTime CreatedDate { get; set; }
+    public DateTime UpdatedDate { get; set; }
 }
 
 public class QuickTaskChecklistItem
@@ -461,4 +510,5 @@ public class QuickTaskChecklistItem
     public int Order { get; set; }
     public DateTime CreatedDate { get; set; }
     public DateTime? CompletedDate { get; set; }
+    public DateTime UpdatedDate { get; set; }
 }

--- a/backend/src/Taskify.Infrastructure/Storage/SubtaskNoteStore.cs
+++ b/backend/src/Taskify.Infrastructure/Storage/SubtaskNoteStore.cs
@@ -5,7 +5,7 @@ namespace Taskify.Infrastructure.Storage;
 public class SubtaskNoteStore
 {
     private readonly string _storageFilePath;
-    private Dictionary<int, string> _notes;
+    private Dictionary<int, SubtaskNoteItem> _notes;
 
     public SubtaskNoteStore(string storageDirectory = "storage")
     {
@@ -24,10 +24,26 @@ public class SubtaskNoteStore
         _notes = LoadNotes();
     }
 
-    public void SaveNote(int subtaskId, string note)
+    public SubtaskNoteItem SaveNote(int subtaskId, string note)
     {
-        _notes[subtaskId] = note;
+        var now = DateTime.UtcNow;
+        if (_notes.TryGetValue(subtaskId, out var existing))
+        {
+            existing.Note = note;
+            existing.UpdatedDate = now;
+            _notes[subtaskId] = existing;
+        }
+        else
+        {
+            _notes[subtaskId] = new SubtaskNoteItem
+            {
+                Note = note,
+                CreatedDate = now,
+                UpdatedDate = now
+            };
+        }
         PersistNotes();
+        return _notes[subtaskId];
     }
 
     public void DeleteNote(int subtaskId)
@@ -38,23 +54,63 @@ public class SubtaskNoteStore
 
     public string? GetNote(int subtaskId)
     {
-        return _notes.TryGetValue(subtaskId, out var note) ? note : null;
+        return _notes.TryGetValue(subtaskId, out var note) ? note.Note : null;
+    }
+
+    public SubtaskNoteItem? GetNoteItem(int subtaskId)
+    {
+        return _notes.TryGetValue(subtaskId, out var note)
+            ? new SubtaskNoteItem
+            {
+                Note = note.Note,
+                CreatedDate = note.CreatedDate,
+                UpdatedDate = note.UpdatedDate
+            }
+            : null;
     }
 
     public Dictionary<int, string> GetAllNotes()
     {
-        return new Dictionary<int, string>(_notes);
+        return _notes.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Note);
     }
 
-    private Dictionary<int, string> LoadNotes()
+    private Dictionary<int, SubtaskNoteItem> LoadNotes()
     {
         try
         {
             if (File.Exists(_storageFilePath))
             {
                 var json = File.ReadAllText(_storageFilePath);
-                return JsonSerializer.Deserialize<Dictionary<int, string>>(json)
-                    ?? new Dictionary<int, string>();
+                var rawMap = JsonSerializer.Deserialize<Dictionary<int, JsonElement>>(json);
+                if (rawMap != null)
+                {
+                    var mapped = new Dictionary<int, SubtaskNoteItem>();
+                    var now = DateTime.UtcNow;
+                    foreach (var kvp in rawMap)
+                    {
+                        if (kvp.Value.ValueKind == JsonValueKind.String)
+                        {
+                            mapped[kvp.Key] = new SubtaskNoteItem
+                            {
+                                Note = kvp.Value.GetString() ?? string.Empty,
+                                CreatedDate = now,
+                                UpdatedDate = now
+                            };
+                            continue;
+                        }
+
+                        if (kvp.Value.ValueKind == JsonValueKind.Object)
+                        {
+                            var item = kvp.Value.Deserialize<SubtaskNoteItem>() ?? new SubtaskNoteItem();
+                            if (item.CreatedDate == default)
+                                item.CreatedDate = now;
+                            if (item.UpdatedDate == default)
+                                item.UpdatedDate = item.CreatedDate;
+                            mapped[kvp.Key] = item;
+                        }
+                    }
+                    return mapped;
+                }
             }
         }
         catch (Exception ex)
@@ -62,7 +118,7 @@ public class SubtaskNoteStore
             Console.WriteLine($"Warning: Failed to load personal notes: {ex.Message}");
         }
 
-        return new Dictionary<int, string>();
+        return new Dictionary<int, SubtaskNoteItem>();
     }
 
     private void PersistNotes()
@@ -80,4 +136,11 @@ public class SubtaskNoteStore
             Console.WriteLine($"Warning: Failed to persist personal notes: {ex.Message}");
         }
     }
+}
+
+public class SubtaskNoteItem
+{
+    public string Note { get; set; } = string.Empty;
+    public DateTime CreatedDate { get; set; }
+    public DateTime UpdatedDate { get; set; }
 }

--- a/backend/src/Taskify.Infrastructure/Storage/SubtaskStore.cs
+++ b/backend/src/Taskify.Infrastructure/Storage/SubtaskStore.cs
@@ -44,6 +44,7 @@ public class SubtaskStore
                     order: i.Order,
                     createdDate: i.CreatedDate,
                     completedDate: i.CompletedDate,
+                    updatedDate: i.UpdatedDate,
                     personalNote: getNote(i.Id)))
                 .ToList();
         }
@@ -66,7 +67,8 @@ public class SubtaskStore
                 IsCompleted = false,
                 Order = newOrder,
                 CreatedDate = now,
-                CompletedDate = null
+                CompletedDate = null,
+                UpdatedDate = now
             };
 
             if (!_model.AssignmentIdToSubtasks.ContainsKey(assignmentId))
@@ -83,6 +85,7 @@ public class SubtaskStore
                 order: newOrder,
                 createdDate: now,
                 completedDate: null,
+                updatedDate: now,
                 personalNote: getNote(id));
         }
     }
@@ -98,6 +101,7 @@ public class SubtaskStore
                 {
                     item.IsCompleted = isCompleted;
                     item.CompletedDate = isCompleted ? DateTime.UtcNow : null;
+                    item.UpdatedDate = DateTime.UtcNow;
                     Persist();
                     return true;
                 }
@@ -116,6 +120,7 @@ public class SubtaskStore
                 if (item != null)
                 {
                     item.Title = title;
+                    item.UpdatedDate = DateTime.UtcNow;
                     Persist();
                     return true;
                 }
@@ -135,6 +140,7 @@ public class SubtaskStore
                 if (item != null)
                 {
                     item.Order = newOrder;
+                    item.UpdatedDate = DateTime.UtcNow;
                     Persist();
                     return true;
                 }
@@ -156,6 +162,7 @@ public class SubtaskStore
                 if (item != null)
                 {
                     item.Order = kvp.Value;
+                    item.UpdatedDate = DateTime.UtcNow;
                 }
             }
 
@@ -194,6 +201,16 @@ public class SubtaskStore
                 {
                     // Ensure non-null collections
                     loaded.AssignmentIdToSubtasks ??= new Dictionary<int, List<SubtaskItem>>();
+                    foreach (var items in loaded.AssignmentIdToSubtasks.Values)
+                    {
+                        foreach (var item in items)
+                        {
+                            if (item.CreatedDate == default)
+                                item.CreatedDate = DateTime.UtcNow;
+                            if (item.UpdatedDate == default)
+                                item.UpdatedDate = item.CreatedDate;
+                        }
+                    }
                     return loaded;
                 }
             }
@@ -237,6 +254,7 @@ public class SubtaskStore
         public int Order { get; set; }
         public DateTime CreatedDate { get; set; }
         public DateTime? CompletedDate { get; set; }
+        public DateTime UpdatedDate { get; set; }
     }
 }
 

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -374,6 +374,13 @@
   word-break: break-word;
 }
 
+.quick-task-item-content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
 .quick-task-comment-edit-input {
   flex: 1;
   min-width: 0;
@@ -400,6 +407,17 @@
   font-size: 0.78rem;
   min-width: 0;
   word-break: break-word;
+}
+
+.subtask-title-block {
+  display: flex;
+  flex-direction: column;
+}
+
+.item-audit-stamp {
+  margin-top: 0.2rem;
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.55);
 }
 
 .quick-tasks-empty,

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -56,6 +56,8 @@ function App() {
   const [subtaskTitleDrafts, setSubtaskTitleDrafts] = useState({});
   const [editingCommentNotes, setEditingCommentNotes] = useState({});
   const [commentNotes, setCommentNotes] = useState({});
+  const [commentNoteTimestamps, setCommentNoteTimestamps] = useState({});
+  const [subtaskNoteTimestamps, setSubtaskNoteTimestamps] = useState({});
   const [commentFlags, setCommentFlags] = useState({});
   const [commentChecklistSummaries, setCommentChecklistSummaries] = useState({});
   const [draggedSubtaskId, setDraggedSubtaskId] = useState(null);
@@ -479,9 +481,7 @@ function App() {
         const notesPromises = data.map((comment) =>
           fetch(`http://localhost:5000/api/comments/${comment.id}/note`)
             .then((res) => (res.ok ? res.json() : null))
-            .then((noteData) =>
-              noteData?.note ? { id: comment.id, note: noteData.note } : null
-            )
+            .then((noteData) => ({ id: comment.id, noteData }))
             .catch(() => null)
         );
         const flagsPromises = data.map((comment) =>
@@ -496,17 +496,30 @@ function App() {
         );
         Promise.all([...notesPromises, ...flagsPromises]).then((results) => {
           const notesState = {};
+          const noteTimestampState = {};
           const flagsState = {};
           results.forEach((result) => {
             if (result) {
-              if ("note" in result) {
-                notesState[result.id] = result.note;
+              if ("noteData" in result) {
+                if (result.noteData?.note) {
+                  notesState[result.id] = result.noteData.note;
+                }
+                if (result.noteData?.createdDate || result.noteData?.updatedDate) {
+                  noteTimestampState[result.id] = {
+                    createdDate: result.noteData.createdDate || null,
+                    updatedDate: result.noteData.updatedDate || null
+                  };
+                }
               } else if ("isFlagged" in result) {
                 flagsState[result.id] = result.isFlagged;
               }
             }
           });
           setCommentNotes((prev) => ({ ...prev, ...notesState }));
+          setCommentNoteTimestamps((prev) => ({
+            ...prev,
+            ...noteTimestampState
+          }));
           setCommentFlags((prev) => ({ ...prev, ...flagsState }));
         });
       } catch (err) {
@@ -836,6 +849,36 @@ function App() {
           });
           return updated;
         });
+        const noteSubtasks = data.filter((subtask) => subtask.personalNote);
+        if (noteSubtasks.length > 0) {
+          Promise.all(
+            noteSubtasks.map((subtask) =>
+              fetch(`http://localhost:5000/api/subtasks/${subtask.id}/note`)
+                .then((res) => (res.ok ? res.json() : null))
+                .then((noteData) => ({ subtaskId: subtask.id, noteData }))
+                .catch(() => null)
+            )
+          ).then((noteResults) => {
+            const nextTimestamps = {};
+            noteResults.forEach((result) => {
+              if (
+                result?.noteData?.createdDate ||
+                result?.noteData?.updatedDate
+              ) {
+                nextTimestamps[result.subtaskId] = {
+                  createdDate: result.noteData.createdDate || null,
+                  updatedDate: result.noteData.updatedDate || null
+                };
+              }
+            });
+            if (Object.keys(nextTimestamps).length > 0) {
+              setSubtaskNoteTimestamps((prev) => ({
+                ...prev,
+                ...nextTimestamps
+              }));
+            }
+          });
+        }
       } catch (err) {
         setError(err.toString());
       } finally {
@@ -904,6 +947,36 @@ function App() {
               });
               return updated;
             });
+            const noteSubtasks = data.filter((subtask) => subtask.personalNote);
+            if (noteSubtasks.length > 0) {
+              Promise.all(
+                noteSubtasks.map((subtask) =>
+                  fetch(`http://localhost:5000/api/subtasks/${subtask.id}/note`)
+                    .then((res) => (res.ok ? res.json() : null))
+                    .then((noteData) => ({ subtaskId: subtask.id, noteData }))
+                    .catch(() => null)
+                )
+              ).then((noteResults) => {
+                const nextTimestamps = {};
+                noteResults.forEach((result) => {
+                  if (
+                    result?.noteData?.createdDate ||
+                    result?.noteData?.updatedDate
+                  ) {
+                    nextTimestamps[result.subtaskId] = {
+                      createdDate: result.noteData.createdDate || null,
+                      updatedDate: result.noteData.updatedDate || null
+                    };
+                  }
+                });
+                if (Object.keys(nextTimestamps).length > 0) {
+                  setSubtaskNoteTimestamps((prev) => ({
+                    ...prev,
+                    ...nextTimestamps
+                  }));
+                }
+              });
+            }
           }
         } catch (fetchErr) {
           console.error("Error refetching subtasks:", fetchErr);
@@ -984,6 +1057,11 @@ function App() {
         delete updated[subtaskId];
         return updated;
       });
+      setSubtaskNoteTimestamps((prev) => {
+        const updated = { ...prev };
+        delete updated[subtaskId];
+        return updated;
+      });
     } catch (err) {
       setError(err.toString());
     }
@@ -1030,6 +1108,33 @@ function App() {
           });
           return updated;
         });
+        const noteSubtasks = data.filter((subtask) => subtask.personalNote);
+        if (noteSubtasks.length > 0) {
+          Promise.all(
+            noteSubtasks.map((subtask) =>
+              fetch(`http://localhost:5000/api/subtasks/${subtask.id}/note`)
+                .then((res) => (res.ok ? res.json() : null))
+                .then((noteData) => ({ subtaskId: subtask.id, noteData }))
+                .catch(() => null)
+            )
+          ).then((noteResults) => {
+            const nextTimestamps = {};
+            noteResults.forEach((result) => {
+              if (result?.noteData?.createdDate || result?.noteData?.updatedDate) {
+                nextTimestamps[result.subtaskId] = {
+                  createdDate: result.noteData.createdDate || null,
+                  updatedDate: result.noteData.updatedDate || null
+                };
+              }
+            });
+            if (Object.keys(nextTimestamps).length > 0) {
+              setSubtaskNoteTimestamps((prev) => ({
+                ...prev,
+                ...nextTimestamps
+              }));
+            }
+          });
+        }
       }
     } catch (err) {
       setError(err.toString());
@@ -1155,6 +1260,22 @@ function App() {
         ...prev,
         [subtaskId]: note || null
       }));
+      const noteResponse = await fetch(
+        `http://localhost:5000/api/subtasks/${subtaskId}/note`
+      );
+      if (noteResponse.ok) {
+        const noteData = await noteResponse.json();
+        setSubtaskNoteTimestamps((prev) => ({
+          ...prev,
+          [subtaskId]:
+            noteData?.createdDate || noteData?.updatedDate
+              ? {
+                  createdDate: noteData.createdDate || null,
+                  updatedDate: noteData.updatedDate || null
+                }
+              : null
+        }));
+      }
       setEditingNotes((prev) => ({
         ...prev,
         [subtaskId]: false
@@ -1252,9 +1373,20 @@ function App() {
         throw new Error("Failed to update comment note");
       }
 
+      const noteData = await response.json();
       setCommentNotes((prev) => ({
         ...prev,
-        [commentId]: note || null
+        [commentId]: noteData?.note || null
+      }));
+      setCommentNoteTimestamps((prev) => ({
+        ...prev,
+        [commentId]:
+          noteData?.createdDate || noteData?.updatedDate
+            ? {
+                createdDate: noteData.createdDate || null,
+                updatedDate: noteData.updatedDate || null
+              }
+            : null
       }));
       setEditingCommentNotes((prev) => ({
         ...prev,
@@ -1623,9 +1755,11 @@ function App() {
                 setCommentSortNewestFirst,
                 commentFlags,
                 commentNotes,
+                commentNoteTimestamps,
                 editingCommentNotes,
                 setEditingCommentNotes,
                 setCommentNotes,
+                setCommentNoteTimestamps,
                 sortCommentsByDate,
                 currentUser,
                 getUserColor,
@@ -1651,6 +1785,7 @@ function App() {
                 subtaskTitleDrafts,
                 editingNotes,
                 subtaskNotes,
+                subtaskNoteTimestamps,
                 handleDragStart,
                 handleDragOver,
                 handleDragLeave,

--- a/client/src/components/AssignmentCard.jsx
+++ b/client/src/components/AssignmentCard.jsx
@@ -31,9 +31,11 @@ function AssignmentCard({
   setCommentSortNewestFirst,
   commentFlags,
   commentNotes,
+  commentNoteTimestamps,
   editingCommentNotes,
   setEditingCommentNotes,
   setCommentNotes,
+  setCommentNoteTimestamps,
   sortCommentsByDate,
   currentUser,
   getUserColor,
@@ -59,6 +61,7 @@ function AssignmentCard({
   subtaskTitleDrafts,
   editingNotes,
   subtaskNotes,
+  subtaskNoteTimestamps,
   handleDragStart,
   handleDragOver,
   handleDragLeave,
@@ -208,9 +211,11 @@ function AssignmentCard({
           setCommentSortNewestFirst={setCommentSortNewestFirst}
           commentFlags={commentFlags}
           commentNotes={commentNotes}
+          commentNoteTimestamps={commentNoteTimestamps}
           editingCommentNotes={editingCommentNotes}
           setEditingCommentNotes={setEditingCommentNotes}
           setCommentNotes={setCommentNotes}
+          setCommentNoteTimestamps={setCommentNoteTimestamps}
           sortCommentsByDate={sortCommentsByDate}
           currentUser={currentUser}
           getUserColor={getUserColor}
@@ -254,6 +259,7 @@ function AssignmentCard({
           subtaskTitleDrafts={subtaskTitleDrafts}
           editingNotes={editingNotes}
           subtaskNotes={subtaskNotes}
+          subtaskNoteTimestamps={subtaskNoteTimestamps}
           handleDragStart={handleDragStart}
           handleDragOver={handleDragOver}
           handleDragLeave={handleDragLeave}

--- a/client/src/components/CommentsSection.jsx
+++ b/client/src/components/CommentsSection.jsx
@@ -10,9 +10,11 @@ function CommentsSection({
   setCommentSortNewestFirst,
   commentFlags,
   commentNotes,
+  commentNoteTimestamps,
   editingCommentNotes,
   setEditingCommentNotes,
   setCommentNotes,
+  setCommentNoteTimestamps,
   sortCommentsByDate,
   currentUser,
   getUserColor,
@@ -25,6 +27,24 @@ function CommentsSection({
   setNewCommentText,
   handleAddComment
 }) {
+  const formatLocalTimestamp = (value) => {
+    if (!value) return "";
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return "";
+    return date.toLocaleString();
+  };
+
+  const formatAuditLabel = (createdDate, updatedDate) => {
+    const created = formatLocalTimestamp(createdDate);
+    const updated = formatLocalTimestamp(updatedDate);
+    if (updated && created && updated !== created) {
+      return `Added ${created} • Updated ${updated}`;
+    }
+    if (updated) return `Added ${updated}`;
+    if (created) return `Added ${created}`;
+    return "";
+  };
+
   const hexToRgba = (hex, opacity) => {
     const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
     if (!result) return hex;
@@ -64,6 +84,15 @@ function CommentsSection({
             [commentId]: data.note
           }));
         }
+        if (data?.createdDate || data?.updatedDate) {
+          setCommentNoteTimestamps((prev) => ({
+            ...prev,
+            [commentId]: {
+              createdDate: data.createdDate || null,
+              updatedDate: data.updatedDate || null
+            }
+          }));
+        }
       })
       .catch((err) => console.error("Error loading comment note:", err));
   };
@@ -72,7 +101,9 @@ function CommentsSection({
     if (commentSubtasks[commentId] || loadingCommentSubtasks[commentId]) return;
 
     setLoadingCommentSubtasks((prev) => ({ ...prev, [commentId]: true }));
-    fetch(`http://localhost:5000/api/comments/${commentId}/subtasks`)
+    fetch(
+      `http://localhost:5000/api/assignments/${assignmentId}/comments/${commentId}/subtasks`
+    )
       .then((res) => (res.ok ? res.json() : []))
       .then((data) => {
         setCommentSubtasks((prev) => ({ ...prev, [commentId]: data || [] }));
@@ -97,7 +128,7 @@ function CommentsSection({
         const entries = await Promise.all(
           allComments.map(async (comment) => {
             const res = await fetch(
-              `http://localhost:5000/api/comments/${comment.id}/subtasks`
+              `http://localhost:5000/api/assignments/${assignmentId}/comments/${comment.id}/subtasks`
             );
             if (!res.ok) return [comment.id, []];
             const items = await res.json();
@@ -132,7 +163,7 @@ function CommentsSection({
 
     try {
       const response = await fetch(
-        `http://localhost:5000/api/comments/${commentId}/subtasks`,
+        `http://localhost:5000/api/assignments/${assignmentId}/comments/${commentId}/subtasks`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -295,11 +326,14 @@ function CommentsSection({
     });
 
     try {
-      await fetch(`http://localhost:5000/api/comments/${commentId}/subtasks/reorder`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ subtaskOrders: orderPayload })
-      });
+      await fetch(
+        `http://localhost:5000/api/assignments/${assignmentId}/comments/${commentId}/subtasks/reorder`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ subtaskOrders: orderPayload })
+        }
+      );
     } catch (err) {
       console.error("Error reordering checklist items:", err);
     } finally {
@@ -627,6 +661,14 @@ function CommentsSection({
                     <span className="comment-note-text">
                       {commentNotes[comment.id]}
                     </span>
+                    {commentNoteTimestamps?.[comment.id] && (
+                      <span className="item-audit-stamp">
+                        {formatAuditLabel(
+                          commentNoteTimestamps[comment.id].createdDate,
+                          commentNoteTimestamps[comment.id].updatedDate
+                        )}
+                      </span>
+                    )}
                   </div>
                 )}
 
@@ -706,6 +748,12 @@ function CommentsSection({
                                     </span>
                                   )}
                                 </label>
+                                <span className="item-audit-stamp">
+                                  {formatAuditLabel(
+                                    item.createdDate,
+                                    item.updatedDate
+                                  )}
+                                </span>
                                 {editingChecklistTitles[item.id] ? (
                                   <>
                                     <button

--- a/client/src/components/QuickTasksSection.jsx
+++ b/client/src/components/QuickTasksSection.jsx
@@ -16,6 +16,23 @@ function QuickTasksSection() {
   const [editingCommentContent, setEditingCommentContent] = useState({});
   const [commentDrafts, setCommentDrafts] = useState({});
   const [draggedChecklistItem, setDraggedChecklistItem] = useState(null);
+  const formatLocalTimestamp = (value) => {
+    if (!value) return "";
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return "";
+    return date.toLocaleString();
+  };
+
+  const formatAuditLabel = (createdDate, updatedDate) => {
+    const created = formatLocalTimestamp(createdDate);
+    const updated = formatLocalTimestamp(updatedDate);
+    if (updated && created && updated !== created) {
+      return `Added ${created} • Updated ${updated}`;
+    }
+    if (updated) return `Added ${updated}`;
+    if (created) return `Added ${created}`;
+    return "";
+  };
 
   const sortedTasks = useMemo(
     () =>
@@ -77,7 +94,11 @@ function QuickTasksSection() {
       if (!response.ok) throw new Error("Failed to toggle quick task");
 
       setTasks((prev) =>
-        prev.map((t) => (t.id === task.id ? { ...t, isCompleted } : t))
+        prev.map((t) =>
+          t.id === task.id
+            ? { ...t, isCompleted, updatedDate: new Date().toISOString() }
+            : t
+        )
       );
     } catch (err) {
       console.error(err);
@@ -123,7 +144,11 @@ function QuickTasksSection() {
       if (!response.ok) throw new Error("Failed to update quick task title");
 
       setTasks((prev) =>
-        prev.map((task) => (task.id === taskId ? { ...task, title } : task))
+        prev.map((task) =>
+          task.id === taskId
+            ? { ...task, title, updatedDate: new Date().toISOString() }
+            : task
+        )
       );
       cancelTaskTitleEdit(taskId);
     } catch (err) {
@@ -195,7 +220,13 @@ function QuickTasksSection() {
             ? {
                 ...task,
                 comments: (task.comments || []).map((comment) =>
-                  comment.id === commentId ? { ...comment, content } : comment
+                  comment.id === commentId
+                    ? {
+                        ...comment,
+                        content,
+                        updatedDate: new Date().toISOString()
+                      }
+                    : comment
                 )
               }
             : task
@@ -281,7 +312,13 @@ function QuickTasksSection() {
             ? {
                 ...task,
                 checklist: (task.checklist || []).map((item) =>
-                  item.id === itemId ? { ...item, isCompleted } : item
+                  item.id === itemId
+                    ? {
+                        ...item,
+                        isCompleted,
+                        updatedDate: new Date().toISOString()
+                      }
+                    : item
                 )
               }
             : task
@@ -350,7 +387,13 @@ function QuickTasksSection() {
             ? {
                 ...task,
                 checklist: (task.checklist || []).map((item) =>
-                  item.id === itemId ? { ...item, title } : item
+                  item.id === itemId
+                    ? {
+                        ...item,
+                        title,
+                        updatedDate: new Date().toISOString()
+                      }
+                    : item
                 )
               }
             : task
@@ -480,13 +523,20 @@ function QuickTasksSection() {
                       autoFocus
                     />
                   ) : (
-                    <span
-                      className={
-                        task.isCompleted ? "quick-task-title done" : "quick-task-title"
-                      }
-                    >
-                      {task.title}
-                    </span>
+                    <div className="quick-task-item-content">
+                      <span
+                        className={
+                          task.isCompleted
+                            ? "quick-task-title done"
+                            : "quick-task-title"
+                        }
+                      >
+                        {task.title}
+                      </span>
+                      <span className="item-audit-stamp">
+                        {formatAuditLabel(task.createdDate, task.updatedDate)}
+                      </span>
+                    </div>
                   )}
                 </label>
 
@@ -570,7 +620,15 @@ function QuickTasksSection() {
                               autoFocus
                             />
                           ) : (
-                            <span>{comment.content}</span>
+                            <div className="quick-task-item-content">
+                              <span>{comment.content}</span>
+                              <span className="item-audit-stamp">
+                                {formatAuditLabel(
+                                  comment.createdDate,
+                                  comment.updatedDate
+                                )}
+                              </span>
+                            </div>
                           )}
                           {editingCommentContent[comment.id] ? (
                             <>
@@ -678,7 +736,17 @@ function QuickTasksSection() {
                               autoFocus
                             />
                           ) : (
-                            <span className={item.isCompleted ? "done" : ""}>{item.title}</span>
+                            <div className="quick-task-item-content">
+                              <span className={item.isCompleted ? "done" : ""}>
+                                {item.title}
+                              </span>
+                              <span className="item-audit-stamp">
+                                {formatAuditLabel(
+                                  item.createdDate,
+                                  item.updatedDate
+                                )}
+                              </span>
+                            </div>
                           )}
                           {editingChecklistTitles[item.id] ? (
                             <>

--- a/client/src/components/SubtasksSection.jsx
+++ b/client/src/components/SubtasksSection.jsx
@@ -10,6 +10,7 @@ function SubtasksSection({
   subtaskTitleDrafts,
   editingNotes,
   subtaskNotes,
+  subtaskNoteTimestamps,
   handleDragStart,
   handleDragOver,
   handleDragLeave,
@@ -30,6 +31,23 @@ function SubtasksSection({
   handleAddSubtask
 }) {
   const assignmentSubtasks = subtasksForAssignment || [];
+  const formatLocalTimestamp = (value) => {
+    if (!value) return "";
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return "";
+    return date.toLocaleString();
+  };
+
+  const formatAuditLabel = (createdDate, updatedDate) => {
+    const created = formatLocalTimestamp(createdDate);
+    const updated = formatLocalTimestamp(updatedDate);
+    if (updated && created && updated !== created) {
+      return `Added ${created} • Updated ${updated}`;
+    }
+    if (updated) return `Added ${updated}`;
+    if (created) return `Added ${created}`;
+    return "";
+  };
 
   return (
     <div className="subtasks-section">
@@ -88,11 +106,19 @@ function SubtasksSection({
                           autoFocus
                         />
                       ) : (
-                        <span
-                          className={`subtask-title ${subtask.isCompleted ? "completed" : ""}`}
-                        >
-                          {subtask.title}
-                        </span>
+                        <div className="subtask-title-block">
+                          <span
+                            className={`subtask-title ${subtask.isCompleted ? "completed" : ""}`}
+                          >
+                            {subtask.title}
+                          </span>
+                          <span className="item-audit-stamp">
+                            {formatAuditLabel(
+                              subtask.createdDate,
+                              subtask.updatedDate
+                            )}
+                          </span>
+                        </div>
                       )}
                     </label>
                     {editingSubtasks[subtask.id] ? (
@@ -233,6 +259,14 @@ function SubtasksSection({
                         <span className="subtask-note-text">
                           {subtaskNotes[subtask.id] || subtask.personalNote}
                         </span>
+                        {subtaskNoteTimestamps?.[subtask.id] && (
+                          <span className="item-audit-stamp">
+                            {formatAuditLabel(
+                              subtaskNoteTimestamps[subtask.id].createdDate,
+                              subtaskNoteTimestamps[subtask.id].updatedDate
+                            )}
+                          </span>
+                        )}
                       </div>
                     )}
                 </div>


### PR DESCRIPTION
## Summary
- persist `createdDate`/`updatedDate` across local quick tasks, quick-task comments/checklists, assignment subtasks, comment notes, subtask notes, and comment checklist items
- surface local audit trail labels in the UI (added/updated timestamps) for quick tasks, subtasks, local notes, and comment checklists
- fix comment checklist bleed across assignments by scoping storage/API usage to `assignmentId + commentId`, with legacy migration fallback

## Test plan
- [x] `dotnet build` (backend)
- [x] `npm run build` (client)
- [x] Validate no linter errors in changed files
- [ ] Add checklist item in one assignment comment and verify it does not appear in another assignment comment
- [ ] Create/edit local quick task/comment/checklist and verify timestamp labels update
- [ ] Create/edit subtask note and comment note and verify timestamp labels display correctly

Closes #76

Made with [Cursor](https://cursor.com)