### PR TITLE
feat(ui): add clear action for assignment search input

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -63,6 +63,7 @@
 .assignment-search-container {
   display: flex;
   align-items: center;
+  position: relative;
 }
 
 .assignment-search-input {
@@ -70,7 +71,7 @@
   background: rgba(255, 255, 255, 0.08);
   border: 1px solid rgba(255, 255, 255, 0.18);
   border-radius: 8px;
-  padding: 0.7rem 0.85rem;
+  padding: 0.7rem 2.3rem 0.7rem 0.85rem;
   color: rgba(255, 255, 255, 0.95);
   font-size: 0.92rem;
   transition: all 0.2s ease;
@@ -84,6 +85,30 @@
 
 .assignment-search-input::placeholder {
   color: rgba(255, 255, 255, 0.55);
+}
+
+.assignment-search-clear {
+  position: absolute;
+  right: 0.45rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 1.6rem;
+  height: 1.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.85);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.assignment-search-clear:hover {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.35);
 }
 
 .assignment-filter-controls {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -91,19 +91,19 @@
   position: absolute;
   right: 0.45rem;
   top: 50%;
-  transform: translateY(-50%);
+  transform: translateY(calc(-50% - 1px));
   width: 1.6rem;
   height: 1.6rem;
+  padding: 0;
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.08);
   color: rgba(255, 255, 255, 0.85);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  display: grid;
+  place-items: center;
   cursor: pointer;
-  font-size: 1rem;
-  line-height: 1;
+  font-size: 1.05rem;
+  line-height: 0;
 }
 
 .assignment-search-clear:hover {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1565,6 +1565,17 @@ function App() {
                 value={assignmentSearch}
                 onChange={(e) => setAssignmentSearch(e.target.value)}
               />
+              {assignmentSearch && (
+                <button
+                  type="button"
+                  className="assignment-search-clear"
+                  onClick={() => setAssignmentSearch("")}
+                  aria-label="Clear assignment search"
+                  title="Clear search"
+                >
+                  ×
+                </button>
+              )}
             </div>
             <div className="assignment-filter-controls">
               <button


### PR DESCRIPTION
## Summary
- add a clear (`×`) button inside the assignment search input
- show the clear action only when search text is present
- keep filters/sort state unchanged while resetting only the search text

## Test plan
- [x] `npm run build`
- [ ] Type in assignment search and confirm clear button appears
- [ ] Click clear button and confirm search resets immediately
- [ ] Confirm filters/sort toggles remain unchanged after clearing

Closes #78

Made with [Cursor](https://cursor.com)