### PR TITLE
feat(attachments): add XLSX attachment preview

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "mammoth": "^1.12.0",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
@@ -1454,6 +1455,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1613,6 +1623,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1628,6 +1651,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/color-convert": {
@@ -1669,6 +1701,18 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2070,6 +2114,15 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2803,6 +2856,18 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -3012,6 +3077,24 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -3020,6 +3103,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xmlbuilder": {

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "mammoth": "^1.12.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -989,6 +989,45 @@
   margin: 0 0 0.8rem 0;
 }
 
+.attachment-preview-xlsx {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.attachment-preview-note {
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 0.78rem;
+}
+
+.attachment-preview-xlsx-table {
+  background: #ffffff;
+  color: #111827;
+  border-radius: 8px;
+  padding: 0.75rem;
+  overflow: auto;
+  max-height: calc(90vh - 230px);
+}
+
+.attachment-preview-xlsx-table table {
+  border-collapse: collapse;
+  width: max-content;
+  min-width: 100%;
+}
+
+.attachment-preview-xlsx-table td,
+.attachment-preview-xlsx-table th {
+  border: 1px solid #d1d5db;
+  padding: 0.35rem 0.5rem;
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.attachment-preview-xlsx-table th {
+  background: #f3f4f6;
+  font-weight: 600;
+}
+
 .attachment-preview-unsupported {
   color: rgba(255, 255, 255, 0.78);
   font-size: 0.9rem;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -699,6 +699,13 @@ function App() {
     ) {
       return "docx";
     }
+    if (
+      ext === "xlsx" ||
+      normalizedType ===
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    ) {
+      return "xlsx";
+    }
     return "unsupported";
   };
 
@@ -748,6 +755,7 @@ function App() {
           objectUrl,
           text: "",
           html: "",
+          previewNote: "",
           error: null
         });
         return;
@@ -762,6 +770,7 @@ function App() {
           objectUrl: "",
           text,
           html: "",
+          previewNote: "",
           error: null
         });
         return;
@@ -787,6 +796,49 @@ function App() {
           objectUrl: "",
           text: "",
           html: result.value || "",
+          previewNote: "",
+          error: null
+        });
+        return;
+      }
+
+      if (kind === "xlsx") {
+        const arrayBuffer = await blob.arrayBuffer();
+        const xlsxModule = await import("xlsx");
+        const xlsxApi = xlsxModule.default ?? xlsxModule;
+        const workbook = xlsxApi.read(arrayBuffer, { type: "array" });
+        const firstSheetName = workbook.SheetNames?.[0];
+
+        if (!firstSheetName) {
+          throw new Error("Workbook has no sheets");
+        }
+
+        const firstSheet = workbook.Sheets[firstSheetName];
+        if (!firstSheet) {
+          throw new Error("Unable to read first sheet");
+        }
+
+        let previewNote = `Sheet: ${firstSheetName}`;
+        if (firstSheet["!ref"]) {
+          const range = xlsxApi.utils.decode_range(firstSheet["!ref"]);
+          const maxPreviewRows = 100;
+          const rowCount = range.e.r - range.s.r + 1;
+          if (rowCount > maxPreviewRows) {
+            range.e.r = range.s.r + maxPreviewRows - 1;
+            firstSheet["!ref"] = xlsxApi.utils.encode_range(range);
+            previewNote += ` (showing first ${maxPreviewRows} rows)`;
+          }
+        }
+
+        const html = xlsxApi.utils.sheet_to_html(firstSheet);
+        setAttachmentPreview({
+          fileName: attachment.fileName,
+          kind,
+          contentType,
+          objectUrl: "",
+          text: "",
+          html,
+          previewNote,
           error: null
         });
         return;
@@ -799,6 +851,7 @@ function App() {
         objectUrl: "",
         text: "",
         html: "",
+        previewNote: "",
         error:
           "Preview is not available for this file type yet. Use Download instead."
       });
@@ -811,6 +864,7 @@ function App() {
         objectUrl: "",
         text: "",
         html: "",
+        previewNote: "",
         error: `Preview failed: ${err.toString()}`
       });
     } finally {
@@ -1905,6 +1959,19 @@ function App() {
                   className="attachment-preview-docx"
                   dangerouslySetInnerHTML={{ __html: attachmentPreview.html }}
                 />
+              )}
+              {attachmentPreview.kind === "xlsx" && (
+                <div className="attachment-preview-xlsx">
+                  {attachmentPreview.previewNote && (
+                    <div className="attachment-preview-note">
+                      {attachmentPreview.previewNote}
+                    </div>
+                  )}
+                  <div
+                    className="attachment-preview-xlsx-table"
+                    dangerouslySetInnerHTML={{ __html: attachmentPreview.html }}
+                  />
+                </div>
               )}
               {attachmentPreview.kind === "unsupported" && (
                 <div className="attachment-preview-unsupported">


### PR DESCRIPTION
## Summary
- add client-side `.xlsx` preview support in the attachment modal by detecting spreadsheet MIME/extensions and parsing with `xlsx`
- render the first worksheet as a readable table preview and show a context note for sheet name / row truncation
- cap large previews to the first 100 rows to keep modal rendering responsive while preserving download as fallback

## Test plan
- [x] `npm run build` in `client`
- [x] `npm run lint` in `client` (existing unrelated lint issue remains in `CommentsSection.jsx`)
- [ ] Upload an `.xlsx` attachment and verify `Preview` opens first-sheet table content
- [ ] Verify large spreadsheets display a truncation note and still allow normal download
- [ ] Verify non-supported file types still show fallback message and download works


Made with [Cursor](https://cursor.com)