### PR TITLE
fix(ui): restore assignment search clear behavior

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -92,6 +92,7 @@
   right: 0.45rem;
   top: 50%;
   transform: translateY(calc(-50% - 1px));
+  z-index: 1;
   width: 1.6rem;
   height: 1.6rem;
   padding: 0;
@@ -101,6 +102,7 @@
   color: rgba(255, 255, 255, 0.85);
   display: grid;
   place-items: center;
+  pointer-events: auto;
   cursor: pointer;
   font-size: 1.05rem;
   line-height: 0;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1584,6 +1584,11 @@ function App() {
   const hotZoneCountInCurrentView = assignmentsInCurrentView.filter((a) =>
     workingOn.has(a.id)
   ).length;
+  const handleClearAssignmentSearch = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setAssignmentSearch("");
+  };
 
   return (
     <div className="app">
@@ -1623,7 +1628,8 @@ function App() {
                 <button
                   type="button"
                   className="assignment-search-clear"
-                  onClick={() => setAssignmentSearch("")}
+                  onMouseDown={handleClearAssignmentSearch}
+                  onClick={handleClearAssignmentSearch}
                   aria-label="Clear assignment search"
                   title="Clear search"
                 >


### PR DESCRIPTION
## Summary
- restore reliable assignment search clearing by handling clear on pointer down and click
- prevent click-loss on the clear control by ensuring it sits above the input hit area

## Test plan
- [x] `npm run build` in `client`
- [x] Enter text in assignment search, click clear (`×`), confirm input resets immediately
- [x] Verify no regression in search filtering and no visual shift in clear icon position


Made with [Cursor](https://cursor.com)