### PR TITLE
feat(ai): add local Ollama comment analysis MVP

### DIFF
--- a/backend/src/Taskify.Api/AI/AiAnalysisService.cs
+++ b/backend/src/Taskify.Api/AI/AiAnalysisService.cs
@@ -40,8 +40,10 @@ public sealed class AiAnalysisService : IAiAnalysisService
             var retryPrompt = $"{userPrompt}\n\nYour previous response was not valid JSON. Return only valid JSON for the schema.";
             var retryGeneration = generation with
             {
-                NumPredict = Math.Min(generation.NumPredict, 320),
-                Temperature = 0.1
+                // Increase budget on retry to avoid truncated JSON responses.
+                NumPredict = Math.Min(generation.NumPredict + 220, 700),
+                Temperature = 0.05,
+                TopP = 0.85
             };
             raw = await _provider.GenerateJsonAsync(systemPrompt, retryPrompt, retryGeneration, cancellationToken);
 
@@ -115,16 +117,28 @@ Rules:
         sb.AppendLine("Existing assignment subtasks:");
 
         var existingSubtasks = request.ExistingSubtasks ?? [];
+        var maxExistingSubtasks = mode switch
+        {
+            "summary" => 12,
+            "actions" => 20,
+            _ => 30
+        };
+        var maxSubtaskTitleLength = mode switch
+        {
+            "summary" => 150,
+            "actions" => 190,
+            _ => 240
+        };
         if (existingSubtasks.Count == 0)
         {
             sb.AppendLine("- None");
         }
         else
         {
-            foreach (var subtask in existingSubtasks.Take(30))
+            foreach (var subtask in existingSubtasks.Take(maxExistingSubtasks))
             {
                 var status = subtask.IsCompleted ? "Completed" : "Open";
-                sb.AppendLine($"- [{status}] {Truncate(subtask.Title, 240)}");
+                sb.AppendLine($"- [{status}] {Truncate(subtask.Title, maxSubtaskTitleLength)}");
             }
         }
 
@@ -132,15 +146,21 @@ Rules:
 
         var maxComments = mode switch
         {
-            "summary" => 24,
+            "summary" => 14,
             "actions" => 30,
             _ => 45
         };
         var maxCommentLength = mode switch
         {
-            "summary" => 700,
+            "summary" => 450,
             "actions" => 900,
             _ => 1100
+        };
+        var maxPersonalNoteLength = mode switch
+        {
+            "summary" => 180,
+            "actions" => 260,
+            _ => 320
         };
 
         foreach (var comment in request.Comments.OrderBy(c => c.CreatedDate).TakeLast(maxComments))
@@ -151,7 +171,7 @@ Rules:
             sb.AppendLine($"  Content: {Truncate(comment.Content, maxCommentLength)}");
             if (request.IncludePersonalNotes && !string.IsNullOrWhiteSpace(comment.PersonalNote))
             {
-                sb.AppendLine($"  PersonalNote: {Truncate(comment.PersonalNote, 320)}");
+                sb.AppendLine($"  PersonalNote: {Truncate(comment.PersonalNote, maxPersonalNoteLength)}");
             }
         }
 
@@ -166,29 +186,20 @@ Rules:
     private static bool TryParseResponse(string raw, out RawCommentAnalysisResponse? parsed)
     {
         parsed = null;
-        try
+        if (TryDeserialize(raw, out parsed))
         {
-            parsed = JsonSerializer.Deserialize<RawCommentAnalysisResponse>(raw, JsonOptions);
-            return parsed != null;
+            return true;
         }
-        catch
-        {
-            var extracted = ExtractJsonObject(raw);
-            if (string.IsNullOrWhiteSpace(extracted))
-            {
-                return false;
-            }
 
-            try
+        foreach (var candidate in ExtractJsonObjects(raw))
+        {
+            if (TryDeserialize(candidate, out parsed))
             {
-                parsed = JsonSerializer.Deserialize<RawCommentAnalysisResponse>(extracted, JsonOptions);
-                return parsed != null;
-            }
-            catch
-            {
-                return false;
+                return true;
             }
         }
+
+        return false;
     }
 
     private CommentAnalysisResponse NormalizeResponse(
@@ -282,21 +293,112 @@ Rules:
         return $"{trimmed[..maxLength]}...(truncated)";
     }
 
-    private static string? ExtractJsonObject(string raw)
+    private static bool TryDeserialize(string raw, out RawCommentAnalysisResponse? parsed)
+    {
+        parsed = null;
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return false;
+        }
+
+        try
+        {
+            parsed = JsonSerializer.Deserialize<RawCommentAnalysisResponse>(raw, JsonOptions);
+            return parsed != null;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static IEnumerable<string> ExtractJsonObjects(string raw)
     {
         if (string.IsNullOrWhiteSpace(raw))
         {
-            return null;
+            yield break;
         }
 
-        var start = raw.IndexOf('{');
-        var end = raw.LastIndexOf('}');
-        if (start < 0 || end <= start)
+        var trimmed = raw.Trim();
+
+        // Try fenced JSON block first (```json ... ```).
+        var fenceStart = trimmed.IndexOf("```json", StringComparison.OrdinalIgnoreCase);
+        if (fenceStart >= 0)
         {
-            return null;
+            var contentStart = fenceStart + "```json".Length;
+            var fenceEnd = trimmed.IndexOf("```", contentStart, StringComparison.Ordinal);
+            if (fenceEnd > contentStart)
+            {
+                var fenced = trimmed[contentStart..fenceEnd].Trim();
+                if (!string.IsNullOrWhiteSpace(fenced))
+                {
+                    yield return fenced;
+                }
+            }
         }
 
-        return raw[start..(end + 1)];
+        // Try balanced object extraction across the raw content.
+        var inString = false;
+        var escaped = false;
+        var depth = 0;
+        var start = -1;
+
+        for (var i = 0; i < trimmed.Length; i++)
+        {
+            var ch = trimmed[i];
+
+            if (inString)
+            {
+                if (escaped)
+                {
+                    escaped = false;
+                    continue;
+                }
+
+                if (ch == '\\')
+                {
+                    escaped = true;
+                    continue;
+                }
+
+                if (ch == '"')
+                {
+                    inString = false;
+                }
+
+                continue;
+            }
+
+            if (ch == '"')
+            {
+                inString = true;
+                continue;
+            }
+
+            if (ch == '{')
+            {
+                if (depth == 0)
+                {
+                    start = i;
+                }
+                depth++;
+                continue;
+            }
+
+            if (ch == '}' && depth > 0)
+            {
+                depth--;
+                if (depth == 0 && start >= 0)
+                {
+                    var candidate = trimmed[start..(i + 1)];
+                    if (!string.IsNullOrWhiteSpace(candidate))
+                    {
+                        yield return candidate;
+                    }
+                    start = -1;
+                }
+            }
+        }
     }
 
     private sealed record RawCommentAnalysisResponse(

--- a/backend/src/Taskify.Api/AI/AiAnalysisService.cs
+++ b/backend/src/Taskify.Api/AI/AiAnalysisService.cs
@@ -130,23 +130,36 @@ Rules:
 
         sb.AppendLine("Comments (oldest to newest):");
 
-        foreach (var comment in request.Comments.OrderBy(c => c.CreatedDate).TakeLast(60))
+        var maxComments = mode switch
+        {
+            "summary" => 24,
+            "actions" => 30,
+            _ => 45
+        };
+        var maxCommentLength = mode switch
+        {
+            "summary" => 700,
+            "actions" => 900,
+            _ => 1100
+        };
+
+        foreach (var comment in request.Comments.OrderBy(c => c.CreatedDate).TakeLast(maxComments))
         {
             sb.AppendLine($"- CommentId: {comment.CommentId}");
             sb.AppendLine($"  Author: {comment.Author}");
             sb.AppendLine($"  Created: {comment.CreatedDate:O}");
-            sb.AppendLine($"  Content: {Truncate(comment.Content, 1200)}");
+            sb.AppendLine($"  Content: {Truncate(comment.Content, maxCommentLength)}");
             if (request.IncludePersonalNotes && !string.IsNullOrWhiteSpace(comment.PersonalNote))
             {
-                sb.AppendLine($"  PersonalNote: {Truncate(comment.PersonalNote, 500)}");
+                sb.AppendLine($"  PersonalNote: {Truncate(comment.PersonalNote, 320)}");
             }
         }
 
         sb.AppendLine();
         sb.AppendLine("Focus by mode:");
-        sb.AppendLine("- summary: emphasize what is being asked, progress so far, blockers, and next immediate steps.");
-        sb.AppendLine("- actions: prioritize concrete action items from assignment description + current subtasks + comments.");
-        sb.AppendLine("- full: provide all sections.");
+        sb.AppendLine("- summary: emphasize what is being asked, progress so far, blockers, and next immediate steps. Keep under 80 words.");
+        sb.AppendLine("- actions: prioritize concrete action items from assignment description + current subtasks + comments. Keep actionItems to max 6 and set suggestedReply to null.");
+        sb.AppendLine("- full: provide all sections, but keep each list concise.");
         return sb.ToString();
     }
 
@@ -160,7 +173,21 @@ Rules:
         }
         catch
         {
-            return false;
+            var extracted = ExtractJsonObject(raw);
+            if (string.IsNullOrWhiteSpace(extracted))
+            {
+                return false;
+            }
+
+            try
+            {
+                parsed = JsonSerializer.Deserialize<RawCommentAnalysisResponse>(extracted, JsonOptions);
+                return parsed != null;
+            }
+            catch
+            {
+                return false;
+            }
         }
     }
 
@@ -233,9 +260,9 @@ Rules:
     {
         return mode switch
         {
-            "summary" => new AiGenerationOptions(NumPredict: 260, Temperature: 0.15, TopP: 0.9),
-            "actions" => new AiGenerationOptions(NumPredict: 320, Temperature: 0.15, TopP: 0.9),
-            _ => new AiGenerationOptions(NumPredict: 420, Temperature: 0.2, TopP: 0.9)
+            "summary" => new AiGenerationOptions(NumPredict: 220, Temperature: 0.1, TopP: 0.9),
+            "actions" => new AiGenerationOptions(NumPredict: 360, Temperature: 0.1, TopP: 0.9),
+            _ => new AiGenerationOptions(NumPredict: 480, Temperature: 0.15, TopP: 0.9)
         };
     }
 
@@ -253,6 +280,23 @@ Rules:
         }
 
         return $"{trimmed[..maxLength]}...(truncated)";
+    }
+
+    private static string? ExtractJsonObject(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return null;
+        }
+
+        var start = raw.IndexOf('{');
+        var end = raw.LastIndexOf('}');
+        if (start < 0 || end <= start)
+        {
+            return null;
+        }
+
+        return raw[start..(end + 1)];
     }
 
     private sealed record RawCommentAnalysisResponse(

--- a/backend/src/Taskify.Api/AI/AiAnalysisService.cs
+++ b/backend/src/Taskify.Api/AI/AiAnalysisService.cs
@@ -1,0 +1,223 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+
+namespace Taskify.Api.AI;
+
+public sealed class AiAnalysisService : IAiAnalysisService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly IAiProvider _provider;
+    private readonly TaskifyAiOptions _options;
+
+    public AiAnalysisService(IAiProvider provider, IOptions<TaskifyAiOptions> options)
+    {
+        _provider = provider;
+        _options = options.Value;
+    }
+
+    public async Task<CommentAnalysisResponse> AnalyzeCommentsAsync(
+        CommentAnalysisRequest request,
+        CancellationToken cancellationToken)
+    {
+        Validate(request);
+
+        var normalizedMode = NormalizeMode(request.Mode);
+        var systemPrompt = BuildSystemPrompt();
+        var userPrompt = BuildUserPrompt(request, normalizedMode);
+
+        var timer = Stopwatch.StartNew();
+        var raw = await _provider.GenerateJsonAsync(systemPrompt, userPrompt, cancellationToken);
+
+        if (!TryParseResponse(raw, out var parsed))
+        {
+            var retryPrompt = $"{userPrompt}\n\nYour previous response was not valid JSON. Return only valid JSON for the schema.";
+            raw = await _provider.GenerateJsonAsync(systemPrompt, retryPrompt, cancellationToken);
+
+            if (!TryParseResponse(raw, out parsed))
+            {
+                throw new InvalidOperationException("AI response could not be parsed as valid JSON.");
+            }
+        }
+
+        timer.Stop();
+        return NormalizeResponse(parsed!, normalizedMode, timer.ElapsedMilliseconds);
+    }
+
+    private static void Validate(CommentAnalysisRequest request)
+    {
+        if (request.AssignmentId <= 0)
+        {
+            throw new ArgumentException("AssignmentId must be greater than 0.");
+        }
+
+        if (request.Comments == null || request.Comments.Count == 0)
+        {
+            throw new ArgumentException("At least one comment is required.");
+        }
+    }
+
+    private static string NormalizeMode(string? mode)
+    {
+        var normalized = (mode ?? "full").Trim().ToLowerInvariant();
+        return normalized is "summary" or "actions" or "full" ? normalized : "full";
+    }
+
+    private static string BuildSystemPrompt()
+    {
+        return """
+You are an assistant for analyzing assignment comments.
+Return only valid JSON with this exact schema:
+{
+  "summary": "string",
+  "keyPoints": ["string"],
+  "actionItems": [
+    {
+      "title": "string",
+      "ownerHint": "string|null",
+      "priority": "low|medium|high",
+      "reason": "string"
+    }
+  ],
+  "risks": ["string"],
+  "suggestedReply": "string|null",
+  "warnings": ["string"]
+}
+
+Rules:
+- Do not include markdown.
+- Keep summary concise and factual.
+- Do not invent facts not in the provided comments.
+- If context is missing, include a warning.
+""";
+    }
+
+    private static string BuildUserPrompt(CommentAnalysisRequest request, string mode)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Mode: {mode}");
+        sb.AppendLine($"Assignment Id: {request.AssignmentId}");
+        sb.AppendLine($"Assignment Title: {request.AssignmentTitle}");
+        sb.AppendLine($"Include Personal Notes: {request.IncludePersonalNotes}");
+        sb.AppendLine("Comments (oldest to newest):");
+
+        foreach (var comment in request.Comments.OrderBy(c => c.CreatedDate))
+        {
+            sb.AppendLine($"- CommentId: {comment.CommentId}");
+            sb.AppendLine($"  Author: {comment.Author}");
+            sb.AppendLine($"  Created: {comment.CreatedDate:O}");
+            sb.AppendLine($"  Content: {comment.Content}");
+            if (request.IncludePersonalNotes && !string.IsNullOrWhiteSpace(comment.PersonalNote))
+            {
+                sb.AppendLine($"  PersonalNote: {comment.PersonalNote}");
+            }
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("Focus by mode:");
+        sb.AppendLine("- summary: emphasize summary + keyPoints, keep actionItems short.");
+        sb.AppendLine("- actions: emphasize actionItems + risks.");
+        sb.AppendLine("- full: provide all sections.");
+        return sb.ToString();
+    }
+
+    private static bool TryParseResponse(string raw, out RawCommentAnalysisResponse? parsed)
+    {
+        parsed = null;
+        try
+        {
+            parsed = JsonSerializer.Deserialize<RawCommentAnalysisResponse>(raw, JsonOptions);
+            return parsed != null;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private CommentAnalysisResponse NormalizeResponse(
+        RawCommentAnalysisResponse parsed,
+        string mode,
+        long elapsedMs)
+    {
+        var keyPoints = (parsed.KeyPoints ?? [])
+            .Where(item => !string.IsNullOrWhiteSpace(item))
+            .Select(item => item.Trim())
+            .ToList();
+
+        var risks = (parsed.Risks ?? [])
+            .Where(item => !string.IsNullOrWhiteSpace(item))
+            .Select(item => item.Trim())
+            .ToList();
+
+        var warnings = (parsed.Warnings ?? [])
+            .Where(item => !string.IsNullOrWhiteSpace(item))
+            .Select(item => item.Trim())
+            .ToList();
+
+        var actionItems = (parsed.ActionItems ?? [])
+            .Where(item => !string.IsNullOrWhiteSpace(item.Title))
+            .Select(item => new CommentActionItem(
+                Title: item.Title.Trim(),
+                OwnerHint: string.IsNullOrWhiteSpace(item.OwnerHint) ? null : item.OwnerHint.Trim(),
+                Priority: NormalizePriority(item.Priority),
+                Reason: string.IsNullOrWhiteSpace(item.Reason) ? "No reason provided." : item.Reason.Trim()
+            ))
+            .ToList();
+
+        var suggestedReply = string.IsNullOrWhiteSpace(parsed.SuggestedReply)
+            ? null
+            : parsed.SuggestedReply.Trim();
+
+        if (mode == "summary" && actionItems.Count > 5)
+        {
+            actionItems = actionItems.Take(5).ToList();
+            warnings.Add("Action items were truncated for summary mode.");
+        }
+
+        var summary = string.IsNullOrWhiteSpace(parsed.Summary)
+            ? "No summary returned by the model."
+            : parsed.Summary.Trim();
+
+        return new CommentAnalysisResponse(
+            Summary: summary,
+            KeyPoints: keyPoints,
+            ActionItems: actionItems,
+            Risks: risks,
+            SuggestedReply: suggestedReply,
+            ModelInfo: new CommentAnalysisModelInfo(
+                Provider: _options.Provider,
+                Model: _options.Model,
+                DurationMs: (int)Math.Min(int.MaxValue, elapsedMs)
+            ),
+            Warnings: warnings
+        );
+    }
+
+    private static string NormalizePriority(string? priority)
+    {
+        var normalized = (priority ?? "").Trim().ToLowerInvariant();
+        return normalized is "low" or "medium" or "high" ? normalized : "medium";
+    }
+
+    private sealed record RawCommentAnalysisResponse(
+        string? Summary,
+        List<string>? KeyPoints,
+        List<RawCommentActionItem>? ActionItems,
+        List<string>? Risks,
+        string? SuggestedReply,
+        List<string>? Warnings
+    );
+
+    private sealed record RawCommentActionItem(
+        string Title,
+        string? OwnerHint,
+        string? Priority,
+        string? Reason
+    );
+}

--- a/backend/src/Taskify.Api/AI/AiAnalysisService.cs
+++ b/backend/src/Taskify.Api/AI/AiAnalysisService.cs
@@ -30,14 +30,20 @@ public sealed class AiAnalysisService : IAiAnalysisService
         var normalizedMode = NormalizeMode(request.Mode);
         var systemPrompt = BuildSystemPrompt();
         var userPrompt = BuildUserPrompt(request, normalizedMode);
+        var generation = GetGenerationOptions(normalizedMode);
 
         var timer = Stopwatch.StartNew();
-        var raw = await _provider.GenerateJsonAsync(systemPrompt, userPrompt, cancellationToken);
+        var raw = await _provider.GenerateJsonAsync(systemPrompt, userPrompt, generation, cancellationToken);
 
         if (!TryParseResponse(raw, out var parsed))
         {
             var retryPrompt = $"{userPrompt}\n\nYour previous response was not valid JSON. Return only valid JSON for the schema.";
-            raw = await _provider.GenerateJsonAsync(systemPrompt, retryPrompt, cancellationToken);
+            var retryGeneration = generation with
+            {
+                NumPredict = Math.Min(generation.NumPredict, 320),
+                Temperature = 0.1
+            };
+            raw = await _provider.GenerateJsonAsync(systemPrompt, retryPrompt, retryGeneration, cancellationToken);
 
             if (!TryParseResponse(raw, out parsed))
             {
@@ -71,7 +77,7 @@ public sealed class AiAnalysisService : IAiAnalysisService
     private static string BuildSystemPrompt()
     {
         return """
-You are an assistant for analyzing assignment comments.
+You are an assistant for analyzing assignment work context.
 Return only valid JSON with this exact schema:
 {
   "summary": "string",
@@ -92,8 +98,9 @@ Return only valid JSON with this exact schema:
 Rules:
 - Do not include markdown.
 - Keep summary concise and factual.
-- Do not invent facts not in the provided comments.
+- Do not invent facts not in the provided assignment details/comments/subtasks.
 - If context is missing, include a warning.
+- For action items, prioritize concrete next steps that move the assignment forward.
 """;
     }
 
@@ -103,25 +110,42 @@ Rules:
         sb.AppendLine($"Mode: {mode}");
         sb.AppendLine($"Assignment Id: {request.AssignmentId}");
         sb.AppendLine($"Assignment Title: {request.AssignmentTitle}");
+        sb.AppendLine($"Assignment Description: {Truncate(request.AssignmentDescription, 2400)}");
         sb.AppendLine($"Include Personal Notes: {request.IncludePersonalNotes}");
+        sb.AppendLine("Existing assignment subtasks:");
+
+        var existingSubtasks = request.ExistingSubtasks ?? [];
+        if (existingSubtasks.Count == 0)
+        {
+            sb.AppendLine("- None");
+        }
+        else
+        {
+            foreach (var subtask in existingSubtasks.Take(30))
+            {
+                var status = subtask.IsCompleted ? "Completed" : "Open";
+                sb.AppendLine($"- [{status}] {Truncate(subtask.Title, 240)}");
+            }
+        }
+
         sb.AppendLine("Comments (oldest to newest):");
 
-        foreach (var comment in request.Comments.OrderBy(c => c.CreatedDate))
+        foreach (var comment in request.Comments.OrderBy(c => c.CreatedDate).TakeLast(60))
         {
             sb.AppendLine($"- CommentId: {comment.CommentId}");
             sb.AppendLine($"  Author: {comment.Author}");
             sb.AppendLine($"  Created: {comment.CreatedDate:O}");
-            sb.AppendLine($"  Content: {comment.Content}");
+            sb.AppendLine($"  Content: {Truncate(comment.Content, 1200)}");
             if (request.IncludePersonalNotes && !string.IsNullOrWhiteSpace(comment.PersonalNote))
             {
-                sb.AppendLine($"  PersonalNote: {comment.PersonalNote}");
+                sb.AppendLine($"  PersonalNote: {Truncate(comment.PersonalNote, 500)}");
             }
         }
 
         sb.AppendLine();
         sb.AppendLine("Focus by mode:");
-        sb.AppendLine("- summary: emphasize summary + keyPoints, keep actionItems short.");
-        sb.AppendLine("- actions: emphasize actionItems + risks.");
+        sb.AppendLine("- summary: emphasize what is being asked, progress so far, blockers, and next immediate steps.");
+        sb.AppendLine("- actions: prioritize concrete action items from assignment description + current subtasks + comments.");
         sb.AppendLine("- full: provide all sections.");
         return sb.ToString();
     }
@@ -203,6 +227,32 @@ Rules:
     {
         var normalized = (priority ?? "").Trim().ToLowerInvariant();
         return normalized is "low" or "medium" or "high" ? normalized : "medium";
+    }
+
+    private static AiGenerationOptions GetGenerationOptions(string mode)
+    {
+        return mode switch
+        {
+            "summary" => new AiGenerationOptions(NumPredict: 260, Temperature: 0.15, TopP: 0.9),
+            "actions" => new AiGenerationOptions(NumPredict: 320, Temperature: 0.15, TopP: 0.9),
+            _ => new AiGenerationOptions(NumPredict: 420, Temperature: 0.2, TopP: 0.9)
+        };
+    }
+
+    private static string Truncate(string? value, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var trimmed = value.Trim();
+        if (trimmed.Length <= maxLength)
+        {
+            return trimmed;
+        }
+
+        return $"{trimmed[..maxLength]}...(truncated)";
     }
 
     private sealed record RawCommentAnalysisResponse(

--- a/backend/src/Taskify.Api/AI/AiContracts.cs
+++ b/backend/src/Taskify.Api/AI/AiContracts.cs
@@ -3,7 +3,9 @@ namespace Taskify.Api.AI;
 public sealed record CommentAnalysisRequest(
     int AssignmentId,
     string AssignmentTitle,
+    string? AssignmentDescription,
     List<CommentAnalysisCommentRequest> Comments,
+    List<CommentAnalysisSubtaskRequest>? ExistingSubtasks = null,
     string Mode = "full",
     bool IncludePersonalNotes = false
 );
@@ -14,6 +16,12 @@ public sealed record CommentAnalysisCommentRequest(
     string Content,
     DateTime CreatedDate,
     string? PersonalNote = null
+);
+
+public sealed record CommentAnalysisSubtaskRequest(
+    int? SubtaskId,
+    string Title,
+    bool IsCompleted
 );
 
 public sealed record CommentAnalysisResponse(
@@ -37,4 +45,10 @@ public sealed record CommentAnalysisModelInfo(
     string Provider,
     string Model,
     int DurationMs
+);
+
+public sealed record AiGenerationOptions(
+    int NumPredict = 420,
+    double Temperature = 0.2,
+    double TopP = 0.9
 );

--- a/backend/src/Taskify.Api/AI/AiContracts.cs
+++ b/backend/src/Taskify.Api/AI/AiContracts.cs
@@ -1,0 +1,40 @@
+namespace Taskify.Api.AI;
+
+public sealed record CommentAnalysisRequest(
+    int AssignmentId,
+    string AssignmentTitle,
+    List<CommentAnalysisCommentRequest> Comments,
+    string Mode = "full",
+    bool IncludePersonalNotes = false
+);
+
+public sealed record CommentAnalysisCommentRequest(
+    int CommentId,
+    string Author,
+    string Content,
+    DateTime CreatedDate,
+    string? PersonalNote = null
+);
+
+public sealed record CommentAnalysisResponse(
+    string Summary,
+    List<string> KeyPoints,
+    List<CommentActionItem> ActionItems,
+    List<string> Risks,
+    string? SuggestedReply,
+    CommentAnalysisModelInfo ModelInfo,
+    List<string> Warnings
+);
+
+public sealed record CommentActionItem(
+    string Title,
+    string? OwnerHint,
+    string Priority,
+    string Reason
+);
+
+public sealed record CommentAnalysisModelInfo(
+    string Provider,
+    string Model,
+    int DurationMs
+);

--- a/backend/src/Taskify.Api/AI/AiInterfaces.cs
+++ b/backend/src/Taskify.Api/AI/AiInterfaces.cs
@@ -1,0 +1,11 @@
+namespace Taskify.Api.AI;
+
+public interface IAiProvider
+{
+    Task<string> GenerateJsonAsync(string systemPrompt, string userPrompt, CancellationToken cancellationToken);
+}
+
+public interface IAiAnalysisService
+{
+    Task<CommentAnalysisResponse> AnalyzeCommentsAsync(CommentAnalysisRequest request, CancellationToken cancellationToken);
+}

--- a/backend/src/Taskify.Api/AI/AiInterfaces.cs
+++ b/backend/src/Taskify.Api/AI/AiInterfaces.cs
@@ -2,7 +2,11 @@ namespace Taskify.Api.AI;
 
 public interface IAiProvider
 {
-    Task<string> GenerateJsonAsync(string systemPrompt, string userPrompt, CancellationToken cancellationToken);
+    Task<string> GenerateJsonAsync(
+        string systemPrompt,
+        string userPrompt,
+        AiGenerationOptions? options,
+        CancellationToken cancellationToken);
 }
 
 public interface IAiAnalysisService

--- a/backend/src/Taskify.Api/AI/OllamaAiProvider.cs
+++ b/backend/src/Taskify.Api/AI/OllamaAiProvider.cs
@@ -1,0 +1,90 @@
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Options;
+
+namespace Taskify.Api.AI;
+
+public sealed class OllamaAiProvider : IAiProvider
+{
+    private readonly HttpClient _httpClient;
+    private readonly TaskifyAiOptions _options;
+
+    public OllamaAiProvider(HttpClient httpClient, IOptions<TaskifyAiOptions> options)
+    {
+        _httpClient = httpClient;
+        _options = options.Value;
+    }
+
+    public async Task<string> GenerateJsonAsync(
+        string systemPrompt,
+        string userPrompt,
+        CancellationToken cancellationToken)
+    {
+        if (!_options.Enabled)
+        {
+            throw new InvalidOperationException("AI features are disabled.");
+        }
+
+        var payload = new OllamaChatRequest(
+            Model: _options.Model,
+            Stream: false,
+            Format: "json",
+            Messages:
+            [
+                new OllamaMessage("system", systemPrompt),
+                new OllamaMessage("user", userPrompt)
+            ],
+            Options: new OllamaOptions(
+                Temperature: 0.2,
+                TopP: 0.9,
+                NumPredict: 700
+            )
+        );
+
+        using var response = await _httpClient.PostAsJsonAsync(
+            "api/chat",
+            payload,
+            cancellationToken
+        );
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var error = await response.Content.ReadAsStringAsync(cancellationToken);
+            throw new HttpRequestException(
+                $"Ollama request failed ({(int)response.StatusCode}): {error}"
+            );
+        }
+
+        var parsed = await response.Content.ReadFromJsonAsync<OllamaChatResponse>(
+            cancellationToken: cancellationToken
+        );
+
+        var content = parsed?.Message?.Content?.Trim();
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            throw new InvalidOperationException("Ollama returned an empty response.");
+        }
+
+        return content;
+    }
+
+    private sealed record OllamaChatRequest(
+        string Model,
+        bool Stream,
+        string Format,
+        List<OllamaMessage> Messages,
+        OllamaOptions Options
+    );
+
+    private sealed record OllamaMessage(string Role, string Content);
+
+    private sealed record OllamaOptions(
+        [property: JsonPropertyName("temperature")] double Temperature,
+        [property: JsonPropertyName("top_p")] double TopP,
+        [property: JsonPropertyName("num_predict")] int NumPredict
+    );
+
+    private sealed record OllamaChatResponse(
+        [property: JsonPropertyName("message")] OllamaMessage? Message
+    );
+}

--- a/backend/src/Taskify.Api/AI/OllamaAiProvider.cs
+++ b/backend/src/Taskify.Api/AI/OllamaAiProvider.cs
@@ -18,6 +18,7 @@ public sealed class OllamaAiProvider : IAiProvider
     public async Task<string> GenerateJsonAsync(
         string systemPrompt,
         string userPrompt,
+        AiGenerationOptions? options,
         CancellationToken cancellationToken)
     {
         if (!_options.Enabled)
@@ -25,6 +26,7 @@ public sealed class OllamaAiProvider : IAiProvider
             throw new InvalidOperationException("AI features are disabled.");
         }
 
+        var generation = options ?? new AiGenerationOptions();
         var payload = new OllamaChatRequest(
             Model: _options.Model,
             Stream: false,
@@ -35,9 +37,9 @@ public sealed class OllamaAiProvider : IAiProvider
                 new OllamaMessage("user", userPrompt)
             ],
             Options: new OllamaOptions(
-                Temperature: 0.2,
-                TopP: 0.9,
-                NumPredict: 700
+                Temperature: generation.Temperature,
+                TopP: generation.TopP,
+                NumPredict: generation.NumPredict
             )
         );
 

--- a/backend/src/Taskify.Api/AI/TaskifyAiOptions.cs
+++ b/backend/src/Taskify.Api/AI/TaskifyAiOptions.cs
@@ -1,0 +1,10 @@
+namespace Taskify.Api.AI;
+
+public sealed class TaskifyAiOptions
+{
+    public bool Enabled { get; set; } = true;
+    public string Provider { get; set; } = "Ollama";
+    public string OllamaBaseUrl { get; set; } = "http://localhost:11434";
+    public string Model { get; set; } = "gemma3:4b";
+    public int TimeoutSeconds { get; set; } = 25;
+}

--- a/backend/src/Taskify.Api/Program.cs
+++ b/backend/src/Taskify.Api/Program.cs
@@ -5,7 +5,9 @@ using Taskify.Application.Subtasks.Services;
 using Taskify.Domain.Interfaces;
 using Taskify.Infrastructure.Storage;
 using Taskify.Api.Infrastructure;
+using Taskify.Api.AI;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
 
 
 var builder = WebApplication.CreateBuilder(args);
@@ -66,6 +68,20 @@ builder.Services.AddScoped<CommentSubtaskService>();
 builder.Services.AddScoped<QuickTaskService>();
 builder.Services.AddScoped<AssignmentBoardService>();
 builder.Services.AddScoped<WorkingOnService>();
+builder.Services.Configure<TaskifyAiOptions>(builder.Configuration.GetSection("TaskifyAI"));
+builder.Services.AddHttpClient<IAiProvider, OllamaAiProvider>((sp, client) =>
+{
+    var options = sp.GetRequiredService<IOptions<TaskifyAiOptions>>().Value;
+    if (!string.IsNullOrWhiteSpace(options.OllamaBaseUrl) &&
+        Uri.TryCreate(options.OllamaBaseUrl, UriKind.Absolute, out var baseUri))
+    {
+        client.BaseAddress = baseUri;
+    }
+
+    var timeoutSeconds = options.TimeoutSeconds <= 0 ? 25 : options.TimeoutSeconds;
+    client.Timeout = TimeSpan.FromSeconds(timeoutSeconds);
+});
+builder.Services.AddScoped<IAiAnalysisService, AiAnalysisService>();
 
 // Verify connector on startup
 builder.Services.AddHostedService<ConnectorHostedService>();
@@ -256,6 +272,42 @@ app.MapPost("api/assignments/{id:int}/comments", async (int id, CommentService s
     cache.Remove(CommentCountsMineCacheKey);
     cache.Remove(CommentCountsAllCacheKey);
     return Results.Ok(c);
+});
+app.MapPost("api/ai/comment-analysis", async (
+    CommentAnalysisRequest body,
+    IAiAnalysisService svc,
+    CancellationToken cancellationToken) =>
+{
+    try
+    {
+        var analysis = await svc.AnalyzeCommentsAsync(body, cancellationToken);
+        return Results.Ok(analysis);
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ex.Message);
+    }
+    catch (TaskCanceledException ex)
+    {
+        return Results.Problem(
+            title: "AI request timed out",
+            detail: ex.Message,
+            statusCode: StatusCodes.Status504GatewayTimeout);
+    }
+    catch (HttpRequestException ex)
+    {
+        return Results.Problem(
+            title: "AI provider unavailable",
+            detail: ex.Message,
+            statusCode: StatusCodes.Status503ServiceUnavailable);
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.Problem(
+            title: "Invalid AI response",
+            detail: ex.Message,
+            statusCode: StatusCodes.Status502BadGateway);
+    }
 });
 app.MapGet("api/comments/{id:int}/note", (int id, CommentNoteService svc) =>
 {

--- a/backend/src/Taskify.Api/appsettings.json
+++ b/backend/src/Taskify.Api/appsettings.json
@@ -7,7 +7,7 @@
     "Provider": "Ollama",
     "OllamaBaseUrl": "http://localhost:11434",
     "Model": "gemma3:4b",
-    "TimeoutSeconds": 75
+    "TimeoutSeconds": 120
   },
   "Logging": {
     "LogLevel": {

--- a/backend/src/Taskify.Api/appsettings.json
+++ b/backend/src/Taskify.Api/appsettings.json
@@ -7,7 +7,7 @@
     "Provider": "Ollama",
     "OllamaBaseUrl": "http://localhost:11434",
     "Model": "gemma3:4b",
-    "TimeoutSeconds": 45
+    "TimeoutSeconds": 75
   },
   "Logging": {
     "LogLevel": {

--- a/backend/src/Taskify.Api/appsettings.json
+++ b/backend/src/Taskify.Api/appsettings.json
@@ -2,6 +2,13 @@
   "Taskify": {
     "DataSource": "MFiles"
   },
+  "TaskifyAI": {
+    "Enabled": true,
+    "Provider": "Ollama",
+    "OllamaBaseUrl": "http://localhost:11434",
+    "Model": "gemma3:4b",
+    "TimeoutSeconds": 25
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/backend/src/Taskify.Api/appsettings.json
+++ b/backend/src/Taskify.Api/appsettings.json
@@ -7,7 +7,7 @@
     "Provider": "Ollama",
     "OllamaBaseUrl": "http://localhost:11434",
     "Model": "gemma3:4b",
-    "TimeoutSeconds": 25
+    "TimeoutSeconds": 45
   },
   "Logging": {
     "LogLevel": {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1124,6 +1124,118 @@
   border-color: rgba(147, 197, 253, 0.65);
 }
 
+.comment-ai-panel {
+  margin-bottom: 0.8rem;
+  padding: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.comment-ai-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+}
+
+.comment-ai-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: rgba(226, 232, 240, 0.92);
+  font-size: 0.8rem;
+}
+
+.comment-ai-run {
+  background: rgba(14, 165, 233, 0.2);
+  color: #bae6fd;
+  border: 1px solid rgba(56, 189, 248, 0.45);
+  border-radius: 6px;
+  padding: 0.45rem 0.7rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.comment-ai-run:hover:not(:disabled) {
+  background: rgba(14, 165, 233, 0.32);
+  border-color: rgba(125, 211, 252, 0.75);
+}
+
+.comment-ai-run:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.comment-ai-error {
+  margin-top: 0.55rem;
+  color: #fca5a5;
+  font-size: 0.8rem;
+}
+
+.comment-ai-result {
+  margin-top: 0.7rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.comment-ai-section {
+  background: rgba(30, 41, 59, 0.58);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 6px;
+  padding: 0.55rem 0.65rem;
+}
+
+.comment-ai-label {
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgba(186, 230, 253, 0.95);
+  margin-bottom: 0.35rem;
+  font-weight: 700;
+}
+
+.comment-ai-summary {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.95);
+  font-size: 0.85rem;
+  line-height: 1.45;
+}
+
+.comment-ai-list {
+  margin: 0;
+  padding-left: 1rem;
+  color: rgba(226, 232, 240, 0.95);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.83rem;
+}
+
+.comment-ai-list.warnings {
+  color: #fcd34d;
+}
+
+.comment-ai-reply {
+  margin: 0;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 6px;
+  padding: 0.6rem;
+  color: rgba(226, 232, 240, 0.95);
+  white-space: pre-wrap;
+  font-size: 0.82rem;
+  font-family: inherit;
+}
+
+.comment-ai-meta {
+  color: rgba(148, 163, 184, 0.9);
+  font-size: 0.74rem;
+}
+
 .comments-list {
   display: flex;
   flex-direction: column;
@@ -1388,6 +1500,13 @@
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
+  border-radius: 6px;
+  padding: 0.1rem 0.2rem;
+}
+
+.comment-subtask-item.drag-over {
+  background: rgba(59, 130, 246, 0.15);
+  border: 1px solid rgba(96, 165, 250, 0.45);
 }
 
 .comment-subtask-checkbox-label {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1132,11 +1132,76 @@
   background: rgba(15, 23, 42, 0.55);
 }
 
+.comment-ai-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.comment-ai-header-right {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.comment-ai-collapse {
+  background: transparent;
+  color: #bae6fd;
+  border: 0;
+  padding: 0;
+  font-size: 0.84rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.comment-ai-collapse:hover {
+  color: #dbeafe;
+}
+
+.comment-ai-elapsed {
+  color: rgba(148, 163, 184, 0.95);
+  font-size: 0.74rem;
+  white-space: nowrap;
+}
+
+.comment-ai-status {
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.7);
+  color: rgba(203, 213, 225, 0.95);
+  font-size: 0.7rem;
+  line-height: 1;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  padding: 0.24rem 0.48rem;
+  white-space: nowrap;
+}
+
+.comment-ai-status.running {
+  border-color: rgba(125, 211, 252, 0.55);
+  background: rgba(3, 105, 161, 0.28);
+  color: #bae6fd;
+}
+
+.comment-ai-status.done {
+  border-color: rgba(74, 222, 128, 0.55);
+  background: rgba(21, 128, 61, 0.26);
+  color: #bbf7d0;
+}
+
+.comment-ai-status.error {
+  border-color: rgba(248, 113, 113, 0.55);
+  background: rgba(153, 27, 27, 0.28);
+  color: #fecaca;
+}
+
 .comment-ai-controls {
   display: flex;
   align-items: center;
   gap: 0.55rem;
   flex-wrap: wrap;
+  margin-top: 0.55rem;
 }
 
 .comment-ai-toggle {
@@ -1180,6 +1245,12 @@
   display: flex;
   flex-direction: column;
   gap: 0.55rem;
+}
+
+.comment-ai-empty {
+  margin-top: 0.6rem;
+  color: rgba(148, 163, 184, 0.92);
+  font-size: 0.8rem;
 }
 
 .comment-ai-section {
@@ -1234,6 +1305,19 @@
 .comment-ai-meta {
   color: rgba(148, 163, 184, 0.9);
   font-size: 0.74rem;
+}
+
+.comment-ai-stale {
+  border-radius: 999px;
+  border: 1px solid rgba(250, 204, 21, 0.5);
+  background: rgba(161, 98, 7, 0.22);
+  color: #fde68a;
+  font-size: 0.7rem;
+  line-height: 1;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  padding: 0.24rem 0.48rem;
+  white-space: nowrap;
 }
 
 .comments-list {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -11,6 +11,7 @@ const SORT_UNREAD_TO_TOP_KEY = "sortUnreadToTop";
 const COMMENT_SORT_NEWEST_FIRST_KEY = "commentSortNewestFirst";
 const AUTO_REFRESH_INTERVAL_SECONDS_KEY = "assignmentAutoRefreshSeconds";
 const SHOW_ALL_ASSIGNMENTS_KEY = "showAllAssignments";
+const AI_SUMMARY_STATE_KEY = "aiSummaryStateByAssignment";
 const SCOPE_MINE = "mine";
 const SCOPE_ALL = "all";
 
@@ -60,6 +61,16 @@ function App() {
   const [subtaskNoteTimestamps, setSubtaskNoteTimestamps] = useState({});
   const [commentFlags, setCommentFlags] = useState({});
   const [commentChecklistSummaries, setCommentChecklistSummaries] = useState({});
+  const [aiSummaryStateByAssignment, setAiSummaryStateByAssignment] = useState(
+    () => {
+      try {
+        const raw = localStorage.getItem(AI_SUMMARY_STATE_KEY);
+        return raw ? JSON.parse(raw) : {};
+      } catch {
+        return {};
+      }
+    }
+  );
   const [draggedSubtaskId, setDraggedSubtaskId] = useState(null);
   const [dragOverSubtaskId, setDragOverSubtaskId] = useState(null);
   const [workingOn, setWorkingOn] = useState(new Set()); // assignmentIds that are marked as "working on"
@@ -292,6 +303,17 @@ function App() {
       // ignore storage write failures
     }
   }, [autoRefreshIntervalSeconds]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        AI_SUMMARY_STATE_KEY,
+        JSON.stringify(aiSummaryStateByAssignment)
+      );
+    } catch {
+      // ignore storage write failures
+    }
+  }, [aiSummaryStateByAssignment]);
 
   useEffect(() => {
     if (!autoRefreshIntervalSeconds) return undefined;
@@ -1838,6 +1860,8 @@ function App() {
                 handleToggleCommentFlag,
                 handleUpdateCommentNote,
                 handleDeleteCommentNote,
+                aiSummaryStateByAssignment,
+                setAiSummaryStateByAssignment,
                 commentChecklistSummaries,
                 setCommentChecklistSummaries,
                 newCommentText,

--- a/client/src/components/AssignmentCard.jsx
+++ b/client/src/components/AssignmentCard.jsx
@@ -43,6 +43,8 @@ function AssignmentCard({
   handleToggleCommentFlag,
   handleUpdateCommentNote,
   handleDeleteCommentNote,
+  aiSummaryStateByAssignment,
+  setAiSummaryStateByAssignment,
   commentChecklistSummaries,
   setCommentChecklistSummaries,
   newCommentText,
@@ -226,6 +228,8 @@ function AssignmentCard({
           handleToggleCommentFlag={handleToggleCommentFlag}
           handleUpdateCommentNote={handleUpdateCommentNote}
           handleDeleteCommentNote={handleDeleteCommentNote}
+          aiSummaryState={aiSummaryStateByAssignment?.[assignment.id]}
+          setAiSummaryStateByAssignment={setAiSummaryStateByAssignment}
           onChecklistSummaryChange={(summary) =>
             setCommentChecklistSummaries((prev) => ({
               ...prev,

--- a/client/src/components/AssignmentCard.jsx
+++ b/client/src/components/AssignmentCard.jsx
@@ -203,6 +203,7 @@ function AssignmentCard({
       {openComments[assignment.id] && (
         <CommentsSection
           assignmentId={assignment.id}
+          assignmentTitle={assignment.title}
           commentsForAssignment={comments[assignment.id]}
           loadingComments={loadingComments[assignment.id]}
           filter={commentFilters[assignment.id]}

--- a/client/src/components/AssignmentCard.jsx
+++ b/client/src/components/AssignmentCard.jsx
@@ -204,6 +204,8 @@ function AssignmentCard({
         <CommentsSection
           assignmentId={assignment.id}
           assignmentTitle={assignment.title}
+          assignmentDescription={assignment.description}
+          assignmentSubtasks={assignmentSubtasks}
           commentsForAssignment={comments[assignment.id]}
           loadingComments={loadingComments[assignment.id]}
           filter={commentFilters[assignment.id]}

--- a/client/src/components/CommentsSection.jsx
+++ b/client/src/components/CommentsSection.jsx
@@ -3,6 +3,8 @@ import React, { useEffect, useState } from "react";
 function CommentsSection({
   assignmentId,
   assignmentTitle,
+  assignmentDescription,
+  assignmentSubtasks,
   commentsForAssignment,
   loadingComments,
   filter,
@@ -365,6 +367,12 @@ function CommentsSection({
         body: JSON.stringify({
           assignmentId,
           assignmentTitle: assignmentTitle || `Assignment ${assignmentId}`,
+          assignmentDescription: assignmentDescription || "",
+          existingSubtasks: (assignmentSubtasks || []).map((subtask) => ({
+            subtaskId: subtask.id || null,
+            title: subtask.title || "",
+            isCompleted: Boolean(subtask.isCompleted)
+          })),
           mode: aiMode,
           includePersonalNotes,
           comments: orderedComments.map((comment) => ({

--- a/client/src/components/CommentsSection.jsx
+++ b/client/src/components/CommentsSection.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 
 function CommentsSection({
   assignmentId,
+  assignmentTitle,
   commentsForAssignment,
   loadingComments,
   filter,
@@ -63,6 +64,11 @@ function CommentsSection({
   const [checklistTitleDrafts, setChecklistTitleDrafts] = useState({});
   const [draggedChecklistItem, setDraggedChecklistItem] = useState(null);
   const [dragOverChecklistItem, setDragOverChecklistItem] = useState(null);
+  const [aiMode, setAiMode] = useState("full");
+  const [includePersonalNotes, setIncludePersonalNotes] = useState(false);
+  const [isAiLoading, setIsAiLoading] = useState(false);
+  const [aiError, setAiError] = useState("");
+  const [aiAnalysis, setAiAnalysis] = useState(null);
 
   const summarizeChecklist = (subtaskMap) => {
     const all = allComments.flatMap((comment) => subtaskMap[comment.id] || []);
@@ -342,6 +348,52 @@ function CommentsSection({
     }
   };
 
+  const handleAnalyzeThread = async () => {
+    if (!allComments.length) return;
+
+    setIsAiLoading(true);
+    setAiError("");
+
+    try {
+      const orderedComments = [...allComments].sort(
+        (a, b) => new Date(a.createdDate).getTime() - new Date(b.createdDate).getTime()
+      );
+
+      const response = await fetch("http://localhost:5000/api/ai/comment-analysis", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          assignmentId,
+          assignmentTitle: assignmentTitle || `Assignment ${assignmentId}`,
+          mode: aiMode,
+          includePersonalNotes,
+          comments: orderedComments.map((comment) => ({
+            commentId: comment.id,
+            author: comment.authorName,
+            content: comment.content,
+            createdDate: comment.createdDate,
+            personalNote: includePersonalNotes
+              ? commentNotes[comment.id] || null
+              : null
+          }))
+        })
+      });
+
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || "Failed to analyze comment thread.");
+      }
+
+      const data = await response.json();
+      setAiAnalysis(data);
+    } catch (err) {
+      setAiAnalysis(null);
+      setAiError(err.toString());
+    } finally {
+      setIsAiLoading(false);
+    }
+  };
+
   let filteredComments = allComments;
 
   if (activeFilter.user) {
@@ -543,6 +595,115 @@ function CommentsSection({
         )}
       </div>
 
+      <div className="comment-ai-panel">
+        <div className="comment-ai-controls">
+          <select
+            className="comment-filter-select"
+            value={aiMode}
+            onChange={(e) => setAiMode(e.target.value)}
+            disabled={isAiLoading}
+          >
+            <option value="full">AI mode: Full analysis</option>
+            <option value="summary">AI mode: Summary</option>
+            <option value="actions">AI mode: Action-focused</option>
+          </select>
+          <label className="comment-ai-toggle">
+            <input
+              type="checkbox"
+              checked={includePersonalNotes}
+              onChange={(e) => setIncludePersonalNotes(e.target.checked)}
+              disabled={isAiLoading}
+            />
+            Include personal notes
+          </label>
+          <button
+            className="comment-ai-run"
+            onClick={handleAnalyzeThread}
+            disabled={isAiLoading || allComments.length === 0}
+            title={
+              allComments.length === 0
+                ? "No comments available to analyze"
+                : "Analyze this comment thread with AI"
+            }
+          >
+            {isAiLoading ? "Analyzing..." : "Analyze Thread"}
+          </button>
+        </div>
+        {aiError && <div className="comment-ai-error">{aiError}</div>}
+        {aiAnalysis && (
+          <div className="comment-ai-result">
+            <div className="comment-ai-section">
+              <div className="comment-ai-label">Summary</div>
+              <p className="comment-ai-summary">{aiAnalysis.summary}</p>
+            </div>
+
+            {Array.isArray(aiAnalysis.keyPoints) && aiAnalysis.keyPoints.length > 0 && (
+              <div className="comment-ai-section">
+                <div className="comment-ai-label">Key points</div>
+                <ul className="comment-ai-list">
+                  {aiAnalysis.keyPoints.map((item, index) => (
+                    <li key={`point-${index}`}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {Array.isArray(aiAnalysis.actionItems) &&
+              aiAnalysis.actionItems.length > 0 && (
+                <div className="comment-ai-section">
+                  <div className="comment-ai-label">Action items</div>
+                  <ul className="comment-ai-list">
+                    {aiAnalysis.actionItems.map((item, index) => (
+                      <li key={`action-${index}`}>
+                        <strong>[{item.priority || "medium"}]</strong> {item.title}
+                        {item.ownerHint ? ` (${item.ownerHint})` : ""} -{" "}
+                        {item.reason}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+            {Array.isArray(aiAnalysis.risks) && aiAnalysis.risks.length > 0 && (
+              <div className="comment-ai-section">
+                <div className="comment-ai-label">Risks</div>
+                <ul className="comment-ai-list">
+                  {aiAnalysis.risks.map((item, index) => (
+                    <li key={`risk-${index}`}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {aiAnalysis.suggestedReply && (
+              <div className="comment-ai-section">
+                <div className="comment-ai-label">Suggested reply</div>
+                <pre className="comment-ai-reply">{aiAnalysis.suggestedReply}</pre>
+              </div>
+            )}
+
+            {(Array.isArray(aiAnalysis.warnings) &&
+              aiAnalysis.warnings.length > 0 && (
+                <div className="comment-ai-section">
+                  <div className="comment-ai-label">Warnings</div>
+                  <ul className="comment-ai-list warnings">
+                    {aiAnalysis.warnings.map((item, index) => (
+                      <li key={`warn-${index}`}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              )) || null}
+
+            {aiAnalysis.modelInfo && (
+              <div className="comment-ai-meta">
+                {aiAnalysis.modelInfo.provider} / {aiAnalysis.modelInfo.model} in{" "}
+                {aiAnalysis.modelInfo.durationMs}ms
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
       <div className="comments-list">
         {loadingComments ? (
           <div className="comments-loading">Loading comments...</div>
@@ -687,7 +848,15 @@ function CommentsSection({
                             .slice()
                             .sort((a, b) => a.order - b.order)
                             .map((item) => (
-                              <div key={item.id} className="comment-subtask-item">
+                              <div
+                                key={item.id}
+                                className={`comment-subtask-item ${
+                                  dragOverChecklistItem?.commentId === comment.id &&
+                                  dragOverChecklistItem?.subtaskId === item.id
+                                    ? "drag-over"
+                                    : ""
+                                }`}
+                              >
                                 <label
                                   className="comment-subtask-checkbox-label"
                                   draggable

--- a/client/src/components/CommentsSection.jsx
+++ b/client/src/components/CommentsSection.jsx
@@ -25,6 +25,8 @@ function CommentsSection({
   handleToggleCommentFlag,
   handleUpdateCommentNote,
   handleDeleteCommentNote,
+  aiSummaryState,
+  setAiSummaryStateByAssignment,
   onChecklistSummaryChange,
   newCommentText,
   setNewCommentText,
@@ -66,11 +68,113 @@ function CommentsSection({
   const [checklistTitleDrafts, setChecklistTitleDrafts] = useState({});
   const [draggedChecklistItem, setDraggedChecklistItem] = useState(null);
   const [dragOverChecklistItem, setDragOverChecklistItem] = useState(null);
-  const [aiMode, setAiMode] = useState("full");
-  const [includePersonalNotes, setIncludePersonalNotes] = useState(false);
+  const [isAiExpanded, setIsAiExpanded] = useState(false);
+  const [includePersonalNotes, setIncludePersonalNotes] = useState(
+    Boolean(aiSummaryState?.includePersonalNotes)
+  );
   const [isAiLoading, setIsAiLoading] = useState(false);
-  const [aiError, setAiError] = useState("");
-  const [aiAnalysis, setAiAnalysis] = useState(null);
+  const [aiError, setAiError] = useState(aiSummaryState?.aiError || "");
+  const [aiAnalysis, setAiAnalysis] = useState(aiSummaryState?.aiAnalysis || null);
+  const [aiElapsedMs, setAiElapsedMs] = useState(
+    Number.isFinite(aiSummaryState?.aiElapsedMs) ? aiSummaryState.aiElapsedMs : null
+  );
+  const [aiLastRunAt, setAiLastRunAt] = useState(aiSummaryState?.aiLastRunAt || null);
+  const [aiLastCommentCount, setAiLastCommentCount] = useState(
+    Number.isFinite(aiSummaryState?.aiLastCommentCount)
+      ? aiSummaryState.aiLastCommentCount
+      : null
+  );
+  const [aiLastLatestCommentDate, setAiLastLatestCommentDate] = useState(
+    aiSummaryState?.aiLastLatestCommentDate || null
+  );
+  const [aiLastDescriptionSignature, setAiLastDescriptionSignature] = useState(
+    aiSummaryState?.aiLastDescriptionSignature || ""
+  );
+  const [aiLastSubtasksSignature, setAiLastSubtasksSignature] = useState(
+    aiSummaryState?.aiLastSubtasksSignature || ""
+  );
+
+  useEffect(() => {
+    setIncludePersonalNotes(Boolean(aiSummaryState?.includePersonalNotes));
+    setAiError(aiSummaryState?.aiError || "");
+    setAiAnalysis(aiSummaryState?.aiAnalysis || null);
+    setAiElapsedMs(
+      Number.isFinite(aiSummaryState?.aiElapsedMs) ? aiSummaryState.aiElapsedMs : null
+    );
+    setAiLastRunAt(aiSummaryState?.aiLastRunAt || null);
+    setAiLastCommentCount(
+      Number.isFinite(aiSummaryState?.aiLastCommentCount)
+        ? aiSummaryState.aiLastCommentCount
+        : null
+    );
+    setAiLastLatestCommentDate(aiSummaryState?.aiLastLatestCommentDate || null);
+    setAiLastDescriptionSignature(aiSummaryState?.aiLastDescriptionSignature || "");
+    setAiLastSubtasksSignature(aiSummaryState?.aiLastSubtasksSignature || "");
+  }, [assignmentId, aiSummaryState]);
+
+  useEffect(() => {
+    setAiSummaryStateByAssignment?.((prev) => {
+      const nextState = {
+        includePersonalNotes,
+        aiError,
+        aiAnalysis,
+        aiElapsedMs,
+        aiLastRunAt,
+        aiLastCommentCount,
+        aiLastLatestCommentDate,
+        aiLastDescriptionSignature,
+        aiLastSubtasksSignature
+      };
+      const current = prev?.[assignmentId];
+
+      if (
+        current?.includePersonalNotes === nextState.includePersonalNotes &&
+        current?.aiError === nextState.aiError &&
+        current?.aiElapsedMs === nextState.aiElapsedMs &&
+        current?.aiLastRunAt === nextState.aiLastRunAt &&
+        current?.aiLastCommentCount === nextState.aiLastCommentCount &&
+        current?.aiLastLatestCommentDate === nextState.aiLastLatestCommentDate &&
+        current?.aiLastDescriptionSignature === nextState.aiLastDescriptionSignature &&
+        current?.aiLastSubtasksSignature === nextState.aiLastSubtasksSignature &&
+        JSON.stringify(current?.aiAnalysis || null) ===
+          JSON.stringify(nextState.aiAnalysis || null)
+      ) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        [assignmentId]: nextState
+      };
+    });
+  }, [
+    assignmentId,
+    includePersonalNotes,
+    aiError,
+    aiAnalysis,
+    aiElapsedMs,
+    aiLastRunAt,
+    aiLastCommentCount,
+    aiLastLatestCommentDate,
+    aiLastDescriptionSignature,
+    aiLastSubtasksSignature,
+    setAiSummaryStateByAssignment
+  ]);
+
+  const getDescriptionSignature = (description) =>
+    (description || "").trim().replace(/\s+/g, " ").toLowerCase();
+
+  const getSubtasksSignature = (items) =>
+    (items || [])
+      .map(
+        (subtask) =>
+          `${subtask.id ?? "na"}|${(subtask.title || "")
+            .trim()
+            .replace(/\s+/g, " ")
+            .toLowerCase()}|${Boolean(subtask.isCompleted) ? 1 : 0}`
+      )
+      .sort()
+      .join("||");
 
   const summarizeChecklist = (subtaskMap) => {
     const all = allComments.flatMap((comment) => subtaskMap[comment.id] || []);
@@ -355,6 +459,8 @@ function CommentsSection({
 
     setIsAiLoading(true);
     setAiError("");
+    setAiElapsedMs(null);
+    const start = performance.now();
 
     try {
       const orderedComments = [...allComments].sort(
@@ -373,7 +479,7 @@ function CommentsSection({
             title: subtask.title || "",
             isCompleted: Boolean(subtask.isCompleted)
           })),
-          mode: aiMode,
+          mode: "summary",
           includePersonalNotes,
           comments: orderedComments.map((comment) => ({
             commentId: comment.id,
@@ -394,9 +500,20 @@ function CommentsSection({
 
       const data = await response.json();
       setAiAnalysis(data);
+      setAiElapsedMs(Math.round(performance.now() - start));
+      setAiLastRunAt(new Date().toISOString());
+      setAiLastCommentCount(orderedComments.length);
+      setAiLastLatestCommentDate(
+        orderedComments.length > 0
+          ? orderedComments[orderedComments.length - 1].createdDate || null
+          : null
+      );
+      setAiLastDescriptionSignature(getDescriptionSignature(assignmentDescription));
+      setAiLastSubtasksSignature(getSubtasksSignature(assignmentSubtasks));
     } catch (err) {
-      setAiAnalysis(null);
       setAiError(err.toString());
+      setAiElapsedMs(Math.round(performance.now() - start));
+      setAiLastRunAt(new Date().toISOString());
     } finally {
       setIsAiLoading(false);
     }
@@ -472,6 +589,54 @@ function CommentsSection({
   }
 
   filteredComments = sortCommentsByDate(filteredComments);
+  const aiStatus = isAiLoading
+    ? "running"
+    : aiError
+      ? "error"
+      : aiAnalysis
+        ? "done"
+        : "idle";
+  const aiStatusLabel = isAiLoading
+    ? "Running"
+    : aiError
+      ? "Failed"
+      : aiAnalysis
+        ? "Done"
+        : "Idle";
+  const formattedAiLastRun = aiLastRunAt
+    ? new Date(aiLastRunAt).toLocaleString()
+    : "";
+  const latestCommentDate = allComments.length
+    ? (() => {
+        const sortedByDate = [...allComments].sort(
+          (a, b) => new Date(a.createdDate).getTime() - new Date(b.createdDate).getTime()
+        );
+        const last = sortedByDate[sortedByDate.length - 1];
+        return last?.createdDate || null;
+      })()
+    : null;
+  const currentDescriptionSignature = getDescriptionSignature(assignmentDescription);
+  const currentSubtasksSignature = getSubtasksSignature(assignmentSubtasks);
+  const commentsChangedSinceAiRun =
+    Boolean(aiAnalysis) &&
+    (aiLastCommentCount !== allComments.length ||
+      (aiLastLatestCommentDate || null) !== (latestCommentDate || null));
+  const descriptionChangedSinceAiRun =
+    Boolean(aiAnalysis) &&
+    aiLastDescriptionSignature !== currentDescriptionSignature;
+  const subtasksChangedSinceAiRun =
+    Boolean(aiAnalysis) && aiLastSubtasksSignature !== currentSubtasksSignature;
+  const hasAssignmentDetailsChangeSinceAiRun =
+    Boolean(aiAnalysis) &&
+    (descriptionChangedSinceAiRun || subtasksChangedSinceAiRun);
+  const hasContextChangesSinceAiRun =
+    commentsChangedSinceAiRun || hasAssignmentDetailsChangeSinceAiRun;
+  const staleReasons = [
+    commentsChangedSinceAiRun ? "Comments changed" : null,
+    descriptionChangedSinceAiRun ? "Description changed" : null,
+    subtasksChangedSinceAiRun ? "Subtasks changed" : null
+  ].filter(Boolean);
+  const staleReasonText = staleReasons.join(", ");
 
   return (
     <div className="comments-section">
@@ -604,111 +769,142 @@ function CommentsSection({
       </div>
 
       <div className="comment-ai-panel">
-        <div className="comment-ai-controls">
-          <select
-            className="comment-filter-select"
-            value={aiMode}
-            onChange={(e) => setAiMode(e.target.value)}
-            disabled={isAiLoading}
-          >
-            <option value="full">AI mode: Full analysis</option>
-            <option value="summary">AI mode: Summary</option>
-            <option value="actions">AI mode: Action-focused</option>
-          </select>
-          <label className="comment-ai-toggle">
-            <input
-              type="checkbox"
-              checked={includePersonalNotes}
-              onChange={(e) => setIncludePersonalNotes(e.target.checked)}
-              disabled={isAiLoading}
-            />
-            Include personal notes
-          </label>
+        <div className="comment-ai-header">
           <button
-            className="comment-ai-run"
-            onClick={handleAnalyzeThread}
-            disabled={isAiLoading || allComments.length === 0}
-            title={
-              allComments.length === 0
-                ? "No comments available to analyze"
-                : "Analyze this comment thread with AI"
-            }
+            type="button"
+            className="comment-ai-collapse"
+            onClick={() => setIsAiExpanded((prev) => !prev)}
+            title={isAiExpanded ? "Collapse AI assistant" : "Expand AI assistant"}
           >
-            {isAiLoading ? "Analyzing..." : "Analyze Thread"}
+            {isAiExpanded ? "▼" : "▶"} AI Summary Assistant
           </button>
-        </div>
-        {aiError && <div className="comment-ai-error">{aiError}</div>}
-        {aiAnalysis && (
-          <div className="comment-ai-result">
-            <div className="comment-ai-section">
-              <div className="comment-ai-label">Summary</div>
-              <p className="comment-ai-summary">{aiAnalysis.summary}</p>
-            </div>
-
-            {Array.isArray(aiAnalysis.keyPoints) && aiAnalysis.keyPoints.length > 0 && (
-              <div className="comment-ai-section">
-                <div className="comment-ai-label">Key points</div>
-                <ul className="comment-ai-list">
-                  {aiAnalysis.keyPoints.map((item, index) => (
-                    <li key={`point-${index}`}>{item}</li>
-                  ))}
-                </ul>
-              </div>
+          <div className="comment-ai-header-right">
+            <span className={`comment-ai-status ${aiStatus}`}>{aiStatusLabel}</span>
+            {aiElapsedMs !== null && (
+              <span className="comment-ai-elapsed">Last run: {aiElapsedMs}ms</span>
             )}
-
-            {Array.isArray(aiAnalysis.actionItems) &&
-              aiAnalysis.actionItems.length > 0 && (
-                <div className="comment-ai-section">
-                  <div className="comment-ai-label">Action items</div>
-                  <ul className="comment-ai-list">
-                    {aiAnalysis.actionItems.map((item, index) => (
-                      <li key={`action-${index}`}>
-                        <strong>[{item.priority || "medium"}]</strong> {item.title}
-                        {item.ownerHint ? ` (${item.ownerHint})` : ""} -{" "}
-                        {item.reason}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-
-            {Array.isArray(aiAnalysis.risks) && aiAnalysis.risks.length > 0 && (
-              <div className="comment-ai-section">
-                <div className="comment-ai-label">Risks</div>
-                <ul className="comment-ai-list">
-                  {aiAnalysis.risks.map((item, index) => (
-                    <li key={`risk-${index}`}>{item}</li>
-                  ))}
-                </ul>
-              </div>
+            {formattedAiLastRun && (
+              <span className="comment-ai-elapsed">at {formattedAiLastRun}</span>
             )}
-
-            {aiAnalysis.suggestedReply && (
-              <div className="comment-ai-section">
-                <div className="comment-ai-label">Suggested reply</div>
-                <pre className="comment-ai-reply">{aiAnalysis.suggestedReply}</pre>
-              </div>
-            )}
-
-            {(Array.isArray(aiAnalysis.warnings) &&
-              aiAnalysis.warnings.length > 0 && (
-                <div className="comment-ai-section">
-                  <div className="comment-ai-label">Warnings</div>
-                  <ul className="comment-ai-list warnings">
-                    {aiAnalysis.warnings.map((item, index) => (
-                      <li key={`warn-${index}`}>{item}</li>
-                    ))}
-                  </ul>
-                </div>
-              )) || null}
-
-            {aiAnalysis.modelInfo && (
-              <div className="comment-ai-meta">
-                {aiAnalysis.modelInfo.provider} / {aiAnalysis.modelInfo.model} in{" "}
-                {aiAnalysis.modelInfo.durationMs}ms
-              </div>
+            {hasContextChangesSinceAiRun && (
+              <span className="comment-ai-stale" title={staleReasonText}>
+                Updated since run
+              </span>
             )}
           </div>
+        </div>
+        {isAiExpanded && (
+          <>
+            <div className="comment-ai-controls">
+              <label className="comment-ai-toggle">
+                <input
+                  type="checkbox"
+                  checked={includePersonalNotes}
+                  onChange={(e) => setIncludePersonalNotes(e.target.checked)}
+                  disabled={isAiLoading}
+                />
+                Include personal notes
+              </label>
+              <button
+                className="comment-ai-run"
+                onClick={handleAnalyzeThread}
+                disabled={isAiLoading || allComments.length === 0}
+                title={
+                  allComments.length === 0
+                    ? "No comments available to analyze"
+                    : "Analyze this comment thread with AI"
+                }
+              >
+                {isAiLoading ? "Analyzing..." : "Analyze Summary"}
+              </button>
+            </div>
+            {aiError && <div className="comment-ai-error">{aiError}</div>}
+            {aiAnalysis && (
+              <div className="comment-ai-result">
+                <div className="comment-ai-section">
+                  <div className="comment-ai-label">Summary</div>
+                  <p className="comment-ai-summary">{aiAnalysis.summary}</p>
+                </div>
+
+                {Array.isArray(aiAnalysis.keyPoints) &&
+                  aiAnalysis.keyPoints.length > 0 && (
+                    <div className="comment-ai-section">
+                      <div className="comment-ai-label">Key points</div>
+                      <ul className="comment-ai-list">
+                        {aiAnalysis.keyPoints.map((item, index) => (
+                          <li key={`point-${index}`}>{item}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+
+                {Array.isArray(aiAnalysis.actionItems) &&
+                  aiAnalysis.actionItems.length > 0 && (
+                    <div className="comment-ai-section">
+                      <div className="comment-ai-label">Action items</div>
+                      <ul className="comment-ai-list">
+                        {aiAnalysis.actionItems.map((item, index) => (
+                          <li key={`action-${index}`}>
+                            <strong>[{item.priority || "medium"}]</strong>{" "}
+                            {item.title}
+                            {item.ownerHint ? ` (${item.ownerHint})` : ""} -{" "}
+                            {item.reason}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+
+                {Array.isArray(aiAnalysis.risks) && aiAnalysis.risks.length > 0 && (
+                  <div className="comment-ai-section">
+                    <div className="comment-ai-label">Risks</div>
+                    <ul className="comment-ai-list">
+                      {aiAnalysis.risks.map((item, index) => (
+                        <li key={`risk-${index}`}>{item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                {aiAnalysis.suggestedReply && (
+                  <div className="comment-ai-section">
+                    <div className="comment-ai-label">Suggested reply</div>
+                    <pre className="comment-ai-reply">{aiAnalysis.suggestedReply}</pre>
+                  </div>
+                )}
+
+                {(Array.isArray(aiAnalysis.warnings) &&
+                  aiAnalysis.warnings.length > 0 && (
+                    <div className="comment-ai-section">
+                      <div className="comment-ai-label">Warnings</div>
+                      <ul className="comment-ai-list warnings">
+                        {aiAnalysis.warnings.map((item, index) => (
+                          <li key={`warn-${index}`}>{item}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )) || null}
+
+                {aiAnalysis.modelInfo && (
+                  <div className="comment-ai-meta">
+                    {aiAnalysis.modelInfo.provider} / {aiAnalysis.modelInfo.model} in{" "}
+                    {aiAnalysis.modelInfo.durationMs}ms
+                  </div>
+                )}
+              </div>
+            )}
+            {!isAiLoading && !aiAnalysis && !aiError && (
+              <div className="comment-ai-empty">
+                Summary-only MVP is enabled. Run analysis to generate a concise
+                assignment summary and suggested next steps.
+              </div>
+            )}
+            {!isAiLoading && aiAnalysis && hasContextChangesSinceAiRun && (
+              <div className="comment-ai-empty">
+                {staleReasonText}. Re-run summary to refresh the analysis.
+              </div>
+            )}
+          </>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- add backend AI analysis infrastructure with provider abstraction (`IAiProvider`, `IAiAnalysisService`) and a local `Ollama` implementation
- introduce `POST /api/ai/comment-analysis` with structured JSON response handling, validation, retry-on-invalid-json, and provider/timeout error mapping
- add a new comment-thread AI panel in the frontend to run analysis and render summary, key points, action items, risks, suggested reply, warnings, and model metadata
- include first-pass AI configuration in API appsettings (`TaskifyAI`) targeting local `gemma3:4b`
- improve runtime reliability by tightening summary-mode prompt budgets, strengthening retry generation settings, and extracting JSON from wrapped model responses
- make AI panel collapsible and summary-focused for MVP, with persisted per-assignment results (status, elapsed time, run timestamp, output)
- add stale-detection indicators for context drift since last run (comments, description, subtasks) with explicit reason messaging

## Test plan
- [x] `npm run build` in `client`
- [x] `dotnet build backend/src/Taskify.Api/Taskify.Api.csproj -p:OutDir=backend/tmp-build-verify2/` (used alternate output path because local API process locks default bin)
- [x] Restart API with production/M-Files env and verify `GET /api/health` returns `{\"status\":\"ok\"}`
- [x] Run `POST /api/ai/comment-analysis` smoke call and verify structured JSON output
- [ ] Open assignment comments, click **Analyze Summary**, verify output persists after hide/show
- [ ] Add new comment / edit description / change subtasks and verify **Updated since run** reason badge appears
- [ ] Toggle **Include personal notes** and verify analysis changes accordingly

Part of #43 (MVP phase for comment analysis).

Made with [Cursor](https://cursor.com)