### PR TITLE
fix(local-data): scope comment notes and stabilize storage profile

### DIFF
--- a/backend/src/Taskify.Api/Program.cs
+++ b/backend/src/Taskify.Api/Program.cs
@@ -92,6 +92,16 @@ const string CommentCountsMineCacheKey = "comment-counts:mine";
 const string CommentCountsAllCacheKey = "comment-counts:all";
 const string AttachmentCountsMineCacheKey = "attachment-counts:mine";
 const string AttachmentCountsAllCacheKey = "attachment-counts:all";
+var configuredDataSource = builder.Configuration["Taskify:DataSource"] ?? "Unknown";
+var configuredVaultGuid = builder.Configuration["MFiles:VaultGuid"] ?? "(not set)";
+
+app.Logger.LogWarning(
+    "Taskify startup profile: Environment={Environment}; DataSource={DataSource}; LocalStorageDirectory={LocalStorageDirectory}; MFilesVaultGuid={VaultGuid}",
+    app.Environment.EnvironmentName,
+    configuredDataSource,
+    localStorageDirectory,
+    configuredVaultGuid
+);
 
 app.UseCors();
 
@@ -309,9 +319,9 @@ app.MapPost("api/ai/comment-analysis", async (
             statusCode: StatusCodes.Status502BadGateway);
     }
 });
-app.MapGet("api/comments/{id:int}/note", (int id, CommentNoteService svc) =>
+app.MapGet("api/assignments/{assignmentId:int}/comments/{id:int}/note", (int assignmentId, int id, CommentNoteService svc) =>
 {
-    var note = svc.GetCommentNoteItem(id);
+    var note = svc.GetCommentNoteItem(assignmentId, id);
     return Results.Ok(new
     {
         note = note?.Note,
@@ -319,14 +329,14 @@ app.MapGet("api/comments/{id:int}/note", (int id, CommentNoteService svc) =>
         updatedDate = note?.UpdatedDate
     });
 });
-app.MapPut("api/comments/{id:int}/note", async (int id, CommentNoteService svc, HttpRequest req) =>
+app.MapPut("api/assignments/{assignmentId:int}/comments/{id:int}/note", async (int assignmentId, int id, CommentNoteService svc, HttpRequest req) =>
 {
     var body = await req.ReadFromJsonAsync<UpdateCommentNoteRequest>();
     if (body == null)
         return Results.BadRequest("body required");
     try
     {
-        var updated = svc.UpdateCommentNote(id, body.Note);
+        var updated = svc.UpdateCommentNote(assignmentId, id, body.Note);
         return Results.Ok(new
         {
             note = updated?.Note,

--- a/backend/src/Taskify.Api/appsettings.json
+++ b/backend/src/Taskify.Api/appsettings.json
@@ -1,6 +1,7 @@
 {
   "Taskify": {
-    "DataSource": "MFiles"
+    "DataSource": "MFiles",
+    "LocalStorageDirectory": "../../publish/api/storage"
   },
   "TaskifyAI": {
     "Enabled": true,

--- a/backend/src/Taskify.Infrastructure/Storage/CommentNoteService.cs
+++ b/backend/src/Taskify.Infrastructure/Storage/CommentNoteService.cs
@@ -11,21 +11,21 @@ public class CommentNoteService
         _noteStore = noteStore;
     }
 
-    public string? GetCommentNote(int commentId)
+    public string? GetCommentNote(int assignmentId, int commentId)
     {
-        return _noteStore.GetNote(commentId);
+        return _noteStore.GetNote(assignmentId, commentId);
     }
 
-    public CommentNoteItem? GetCommentNoteItem(int commentId)
+    public CommentNoteItem? GetCommentNoteItem(int assignmentId, int commentId)
     {
-        return _noteStore.GetNoteItem(commentId);
+        return _noteStore.GetNoteItem(assignmentId, commentId);
     }
 
-    public CommentNoteItem? UpdateCommentNote(int commentId, string? note)
+    public CommentNoteItem? UpdateCommentNote(int assignmentId, int commentId, string? note)
     {
         if (string.IsNullOrWhiteSpace(note))
         {
-            _noteStore.DeleteNote(commentId);
+            _noteStore.DeleteNote(assignmentId, commentId);
             return null;
         }
         else
@@ -33,7 +33,7 @@ public class CommentNoteService
             if (note.Length > 1000)
                 throw new ArgumentException("Comment note cannot exceed 1000 characters");
             
-            return _noteStore.SaveNote(commentId, note);
+            return _noteStore.SaveNote(assignmentId, commentId, note);
         }
     }
 }

--- a/backend/src/Taskify.Infrastructure/Storage/CommentNoteStore.cs
+++ b/backend/src/Taskify.Infrastructure/Storage/CommentNoteStore.cs
@@ -5,7 +5,7 @@ namespace Taskify.Infrastructure.Storage;
 public class CommentNoteStore
 {
     private readonly string _storageFilePath;
-    private Dictionary<int, CommentNoteItem> _notes;
+    private Dictionary<string, CommentNoteItem> _notes;
 
     public CommentNoteStore(string storageDirectory = "storage")
     {
@@ -24,42 +24,62 @@ public class CommentNoteStore
         _notes = LoadNotes();
     }
 
-    public CommentNoteItem SaveNote(int commentId, string note)
+    public CommentNoteItem SaveNote(int assignmentId, int commentId, string note)
     {
+        var scopedKey = BuildScopedKey(assignmentId, commentId);
+        var legacyKey = BuildLegacyKey(commentId);
         var now = DateTime.UtcNow;
-        if (_notes.TryGetValue(commentId, out var existing))
+        if (_notes.TryGetValue(scopedKey, out var existing))
         {
             existing.Note = note;
             existing.UpdatedDate = now;
-            _notes[commentId] = existing;
+            _notes[scopedKey] = existing;
         }
         else
         {
-            _notes[commentId] = new CommentNoteItem
+            _notes[scopedKey] = new CommentNoteItem
             {
                 Note = note,
                 CreatedDate = now,
                 UpdatedDate = now
             };
         }
+
+        // Remove legacy key once a scoped note is saved.
+        _notes.Remove(legacyKey);
         PersistNotes();
-        return _notes[commentId];
+        return _notes[scopedKey];
     }
 
-    public void DeleteNote(int commentId)
+    public void DeleteNote(int assignmentId, int commentId)
     {
-        _notes.Remove(commentId);
+        _notes.Remove(BuildScopedKey(assignmentId, commentId));
+        _notes.Remove(BuildLegacyKey(commentId));
         PersistNotes();
     }
 
-    public string? GetNote(int commentId)
+    public string? GetNote(int assignmentId, int commentId)
     {
-        return _notes.TryGetValue(commentId, out var note) ? note.Note : null;
+        return GetNoteItem(assignmentId, commentId)?.Note;
     }
 
-    public CommentNoteItem? GetNoteItem(int commentId)
+    public CommentNoteItem? GetNoteItem(int assignmentId, int commentId)
     {
-        return _notes.TryGetValue(commentId, out var note)
+        var scopedKey = BuildScopedKey(assignmentId, commentId);
+        if (!_notes.TryGetValue(scopedKey, out var note))
+        {
+            // One-time migration path for legacy storage keyed only by commentId.
+            var legacyKey = BuildLegacyKey(commentId);
+            if (_notes.TryGetValue(legacyKey, out var legacy))
+            {
+                _notes[scopedKey] = legacy;
+                _notes.Remove(legacyKey);
+                PersistNotes();
+                note = legacy;
+            }
+        }
+
+        return note != null
             ? new CommentNoteItem
             {
                 Note = note.Note,
@@ -69,22 +89,22 @@ public class CommentNoteStore
             : null;
     }
 
-    public Dictionary<int, string> GetAllNotes()
+    public Dictionary<string, string> GetAllNotes()
     {
         return _notes.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Note);
     }
 
-    private Dictionary<int, CommentNoteItem> LoadNotes()
+    private Dictionary<string, CommentNoteItem> LoadNotes()
     {
         try
         {
             if (File.Exists(_storageFilePath))
             {
                 var json = File.ReadAllText(_storageFilePath);
-                var rawMap = JsonSerializer.Deserialize<Dictionary<int, JsonElement>>(json);
+                var rawMap = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
                 if (rawMap != null)
                 {
-                    var mapped = new Dictionary<int, CommentNoteItem>();
+                    var mapped = new Dictionary<string, CommentNoteItem>();
                     var now = DateTime.UtcNow;
                     foreach (var kvp in rawMap)
                     {
@@ -118,7 +138,7 @@ public class CommentNoteStore
             Console.WriteLine($"Warning: Failed to load comment notes: {ex.Message}");
         }
 
-        return new Dictionary<int, CommentNoteItem>();
+        return new Dictionary<string, CommentNoteItem>();
     }
 
     private void PersistNotes()
@@ -135,6 +155,16 @@ public class CommentNoteStore
         {
             Console.WriteLine($"Warning: Failed to persist comment notes: {ex.Message}");
         }
+    }
+
+    private static string BuildScopedKey(int assignmentId, int commentId)
+    {
+        return $"{assignmentId}:{commentId}";
+    }
+
+    private static string BuildLegacyKey(int commentId)
+    {
+        return commentId.ToString();
     }
 }
 

--- a/backend/src/Taskify.Infrastructure/Storage/CommentSubtaskStore.cs
+++ b/backend/src/Taskify.Infrastructure/Storage/CommentSubtaskStore.cs
@@ -29,7 +29,16 @@ public class CommentSubtaskStore
             if (!_model.CommentScopeToSubtasks.TryGetValue(scopeKey, out var items))
             {
                 var legacyScopeKey = BuildLegacyScopeKey(commentId);
-                _model.CommentScopeToSubtasks.TryGetValue(legacyScopeKey, out items);
+                if (_model.CommentScopeToSubtasks.TryGetValue(legacyScopeKey, out var legacyItems))
+                {
+                    // One-time migration for legacy commentId-only scopes.
+                    // Legacy data cannot distinguish assignments, so we bind it
+                    // to the first accessed assignment scope to prevent cross-bleed.
+                    items = legacyItems;
+                    _model.CommentScopeToSubtasks[scopeKey] = items;
+                    _model.CommentScopeToSubtasks.Remove(legacyScopeKey);
+                    Persist();
+                }
             }
 
             if (items == null)

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -501,9 +501,15 @@ function App() {
         }));
         // Load comment notes and flags for all comments
         const notesPromises = data.map((comment) =>
-          fetch(`http://localhost:5000/api/comments/${comment.id}/note`)
+          fetch(
+            `http://localhost:5000/api/assignments/${assignmentId}/comments/${comment.id}/note`
+          )
             .then((res) => (res.ok ? res.json() : null))
-            .then((noteData) => ({ id: comment.id, noteData }))
+            .then((noteData) => ({
+              commentId: comment.id,
+              noteKey: getCommentNoteKey(assignmentId, comment.id),
+              noteData
+            }))
             .catch(() => null)
         );
         const flagsPromises = data.map((comment) =>
@@ -524,10 +530,10 @@ function App() {
             if (result) {
               if ("noteData" in result) {
                 if (result.noteData?.note) {
-                  notesState[result.id] = result.noteData.note;
+                  notesState[result.noteKey] = result.noteData.note;
                 }
                 if (result.noteData?.createdDate || result.noteData?.updatedDate) {
-                  noteTimestampState[result.id] = {
+                  noteTimestampState[result.noteKey] = {
                     createdDate: result.noteData.createdDate || null,
                     updatedDate: result.noteData.updatedDate || null
                   };
@@ -1432,10 +1438,13 @@ function App() {
     }
   };
 
-  const handleUpdateCommentNote = async (commentId, note) => {
+  const getCommentNoteKey = (assignmentId, commentId) =>
+    `${assignmentId}:${commentId}`;
+
+  const handleUpdateCommentNote = async (assignmentId, commentId, note) => {
     try {
       const response = await fetch(
-        `http://localhost:5000/api/comments/${commentId}/note`,
+        `http://localhost:5000/api/assignments/${assignmentId}/comments/${commentId}/note`,
         {
           method: "PUT",
           headers: {
@@ -1450,13 +1459,14 @@ function App() {
       }
 
       const noteData = await response.json();
+      const noteKey = getCommentNoteKey(assignmentId, commentId);
       setCommentNotes((prev) => ({
         ...prev,
-        [commentId]: noteData?.note || null
+        [noteKey]: noteData?.note || null
       }));
       setCommentNoteTimestamps((prev) => ({
         ...prev,
-        [commentId]:
+        [noteKey]:
           noteData?.createdDate || noteData?.updatedDate
             ? {
                 createdDate: noteData.createdDate || null,
@@ -1466,16 +1476,16 @@ function App() {
       }));
       setEditingCommentNotes((prev) => ({
         ...prev,
-        [commentId]: false
+        [noteKey]: false
       }));
     } catch (err) {
       setError(err.toString());
     }
   };
 
-  const handleDeleteCommentNote = async (commentId) => {
+  const handleDeleteCommentNote = async (assignmentId, commentId) => {
     if (window.confirm("Are you sure you want to delete this personal note?")) {
-      await handleUpdateCommentNote(commentId, null);
+      await handleUpdateCommentNote(assignmentId, commentId, null);
     }
   };
 

--- a/client/src/components/CommentsSection.jsx
+++ b/client/src/components/CommentsSection.jsx
@@ -93,6 +93,7 @@ function CommentsSection({
   const [aiLastSubtasksSignature, setAiLastSubtasksSignature] = useState(
     aiSummaryState?.aiLastSubtasksSignature || ""
   );
+  const getCommentNoteKey = (commentId) => `${assignmentId}:${commentId}`;
 
   useEffect(() => {
     setIncludePersonalNotes(Boolean(aiSummaryState?.includePersonalNotes));
@@ -185,21 +186,24 @@ function CommentsSection({
   };
 
   const loadCommentNoteIfNeeded = (commentId) => {
-    if (commentNotes[commentId]) return;
+    const noteKey = getCommentNoteKey(commentId);
+    if (commentNotes[noteKey]) return;
 
-    fetch(`http://localhost:5000/api/comments/${commentId}/note`)
+    fetch(
+      `http://localhost:5000/api/assignments/${assignmentId}/comments/${commentId}/note`
+    )
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
         if (data?.note) {
           setCommentNotes((prev) => ({
             ...prev,
-            [commentId]: data.note
+            [noteKey]: data.note
           }));
         }
         if (data?.createdDate || data?.updatedDate) {
           setCommentNoteTimestamps((prev) => ({
             ...prev,
-            [commentId]: {
+            [noteKey]: {
               createdDate: data.createdDate || null,
               updatedDate: data.updatedDate || null
             }
@@ -487,7 +491,7 @@ function CommentsSection({
             content: comment.content,
             createdDate: comment.createdDate,
             personalNote: includePersonalNotes
-              ? commentNotes[comment.id] || null
+              ? commentNotes[getCommentNoteKey(comment.id)] || null
               : null
           }))
         })
@@ -570,9 +574,13 @@ function CommentsSection({
 
   if (activeFilter.note) {
     if (activeFilter.note === "has-note") {
-      filteredComments = filteredComments.filter((c) => commentNotes[c.id]);
+      filteredComments = filteredComments.filter(
+        (c) => commentNotes[getCommentNoteKey(c.id)]
+      );
     } else if (activeFilter.note === "no-note") {
-      filteredComments = filteredComments.filter((c) => !commentNotes[c.id]);
+      filteredComments = filteredComments.filter(
+        (c) => !commentNotes[getCommentNoteKey(c.id)]
+      );
     }
   }
 
@@ -913,6 +921,7 @@ function CommentsSection({
           <div className="comments-loading">Loading comments...</div>
         ) : filteredComments.length > 0 ? (
           filteredComments.map((comment) => {
+            const noteKey = getCommentNoteKey(comment.id);
             const isCurrentUser =
               currentUser && comment.authorName === currentUser;
             const userColor = getUserColor(comment.authorName);
@@ -957,32 +966,32 @@ function CommentsSection({
                     onClick={() => {
                       setEditingCommentNotes((prev) => ({
                         ...prev,
-                        [comment.id]: !prev[comment.id]
+                        [noteKey]: !prev[noteKey]
                       }));
                       loadCommentNoteIfNeeded(comment.id);
                       loadCommentSubtasksIfNeeded(comment.id);
                     }}
                     title={
-                      commentNotes[comment.id]
+                      commentNotes[noteKey]
                         ? "Edit personal note"
                         : "Add personal note"
                     }
                   >
-                    {commentNotes[comment.id] ? "📝" : "📄"}
+                    {commentNotes[noteKey] ? "📝" : "📄"}
                   </button>
                 </div>
                 <div className="comment-content">{comment.content}</div>
 
-                {editingCommentNotes[comment.id] && (
+                {editingCommentNotes[noteKey] && (
                   <div className="comment-note-editor">
                     <textarea
                       className="comment-note-input"
                       placeholder="Add a personal note about this comment..."
-                      value={commentNotes[comment.id] || ""}
+                      value={commentNotes[noteKey] || ""}
                       onChange={(e) =>
                         setCommentNotes((prev) => ({
                           ...prev,
-                          [comment.id]: e.target.value
+                          [noteKey]: e.target.value
                         }))
                       }
                       rows={3}
@@ -991,7 +1000,11 @@ function CommentsSection({
                       <button
                         className="comment-note-save"
                         onClick={() =>
-                          handleUpdateCommentNote(comment.id, commentNotes[comment.id])
+                          handleUpdateCommentNote(
+                            assignmentId,
+                            comment.id,
+                            commentNotes[noteKey]
+                          )
                         }
                       >
                         Save
@@ -1001,7 +1014,7 @@ function CommentsSection({
                         onClick={() =>
                           setEditingCommentNotes((prev) => ({
                             ...prev,
-                            [comment.id]: false
+                            [noteKey]: false
                           }))
                         }
                       >
@@ -1011,26 +1024,28 @@ function CommentsSection({
                   </div>
                 )}
 
-                {!editingCommentNotes[comment.id] && commentNotes[comment.id] && (
+                {!editingCommentNotes[noteKey] && commentNotes[noteKey] && (
                   <div className="comment-note-display">
                     <div className="comment-note-header">
                       <span className="comment-note-label">Personal Note:</span>
                       <button
                         className="comment-note-delete-button"
-                        onClick={() => handleDeleteCommentNote(comment.id)}
+                        onClick={() =>
+                          handleDeleteCommentNote(assignmentId, comment.id)
+                        }
                         title="Delete personal note"
                       >
                         🗑️
                       </button>
                     </div>
                     <span className="comment-note-text">
-                      {commentNotes[comment.id]}
+                      {commentNotes[noteKey]}
                     </span>
-                    {commentNoteTimestamps?.[comment.id] && (
+                    {commentNoteTimestamps?.[noteKey] && (
                       <span className="item-audit-stamp">
                         {formatAuditLabel(
-                          commentNoteTimestamps[comment.id].createdDate,
-                          commentNoteTimestamps[comment.id].updatedDate
+                          commentNoteTimestamps[noteKey].createdDate,
+                          commentNoteTimestamps[noteKey].updatedDate
                         )}
                       </span>
                     )}


### PR DESCRIPTION
## Summary
- scope comment-note storage and APIs by `assignmentId:commentId` to eliminate cross-assignment note bleed
- migrate legacy comment-note keys on read/write and update frontend note state keys + fetch routes to use assignment scope consistently
- fix legacy comment checklist bleed by migrating legacy `commentId` checklist scopes into assignment-scoped keys on first read
- pin a canonical local storage directory for API runs and add startup diagnostics logging (environment, datasource, storage path, vault GUID) to make profile drift immediately visible

## Test plan
- [x] `npm run build` in `client`
- [x] `dotnet build backend/src/Taskify.Api/Taskify.Api.csproj -p:OutDir=backend/tmp-build-verify5/`
- [x] Run API in production mode (`--no-launch-profile`) and verify startup diagnostics log prints expected environment, storage directory, and vault GUID
- [x] Verify assignment counts return expected values (mine/team) after restart
- [x] Validate note isolation by writing to same `commentId` under different assignments and verifying values stay independent
- [x] Validate checklist isolation for shared `commentId` across assignments (item appears only in the intended assignment after migration)

Fixes #84

Made with [Cursor](https://cursor.com)