### PR TITLE
Quick Tasks UX: collapsible panel and completed task filtering

### DIFF
--- a/backend/src/Taskify.Api/Properties/launchSettings.json
+++ b/backend/src/Taskify.Api/Properties/launchSettings.json
@@ -3,7 +3,7 @@
         "Taskify.Api": {
             "commandName": "Project",
             "environmentVariables": {
-                "ASPNETCORE_ENVIRONMENT": "Development"
+                "ASPNETCORE_ENVIRONMENT": "Production"
             },
             "applicationUrl": "http://localhost:5000"
     }

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -231,11 +231,31 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 0.6rem;
+  flex-wrap: wrap;
 }
 
 .quick-tasks-header h2 {
   margin: 0;
   font-size: 1rem;
+}
+
+.quick-tasks-collapse-toggle {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.92);
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.86rem;
+  font-weight: 600;
+  padding: 0.35rem 0.65rem;
+}
+
+.quick-tasks-counts {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
 }
 
 .quick-tasks-count {
@@ -245,6 +265,51 @@
   font-size: 0.75rem;
   border-radius: 999px;
   padding: 0.15rem 0.55rem;
+}
+
+.quick-tasks-count.open {
+  border-color: rgba(56, 189, 248, 0.35);
+  color: #7dd3fc;
+}
+
+.quick-tasks-count.done {
+  background: rgba(110, 231, 183, 0.16);
+  border-color: rgba(110, 231, 183, 0.35);
+  color: #6ee7b7;
+}
+
+.quick-tasks-count.total {
+  background: rgba(203, 213, 225, 0.14);
+  border-color: rgba(203, 213, 225, 0.3);
+  color: #cbd5e1;
+}
+
+.quick-tasks-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.quick-task-visibility-toggle {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.86);
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.77rem;
+  padding: 0.32rem 0.6rem;
+}
+
+.quick-task-visibility-toggle.active {
+  border-color: rgba(110, 231, 183, 0.45);
+  background: rgba(110, 231, 183, 0.14);
+  color: #a7f3d0;
+}
+
+.quick-tasks-hidden-hint {
+  color: rgba(255, 255, 255, 0.58);
+  font-size: 0.74rem;
 }
 
 .quick-task-add-row,

--- a/client/src/components/QuickTasksSection.jsx
+++ b/client/src/components/QuickTasksSection.jsx
@@ -1,10 +1,26 @@
 import React, { useEffect, useMemo, useState } from "react";
 
 const QUICK_TASKS_API_URL = "http://localhost:5000/api/quick-tasks";
+const QUICK_TASKS_COLLAPSED_KEY = "quickTasksCollapsed";
+const QUICK_TASKS_SHOW_COMPLETED_KEY = "quickTasksShowCompleted";
 
 function QuickTasksSection() {
   const [tasks, setTasks] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [isCollapsed, setIsCollapsed] = useState(() => {
+    try {
+      return localStorage.getItem(QUICK_TASKS_COLLAPSED_KEY) === "true";
+    } catch {
+      return false;
+    }
+  });
+  const [showCompletedTasks, setShowCompletedTasks] = useState(() => {
+    try {
+      return localStorage.getItem(QUICK_TASKS_SHOW_COMPLETED_KEY) === "true";
+    } catch {
+      return false;
+    }
+  });
   const [newTaskTitle, setNewTaskTitle] = useState("");
   const [openTaskDetails, setOpenTaskDetails] = useState({});
   const [newComments, setNewComments] = useState({});
@@ -44,6 +60,30 @@ function QuickTasksSection() {
       }),
     [tasks]
   );
+  const openTaskCount = tasks.filter((task) => !task.isCompleted).length;
+  const completedTaskCount = tasks.filter((task) => task.isCompleted).length;
+  const visibleTasks = showCompletedTasks
+    ? sortedTasks
+    : sortedTasks.filter((task) => !task.isCompleted);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(QUICK_TASKS_COLLAPSED_KEY, String(isCollapsed));
+    } catch {
+      // ignore storage write failures
+    }
+  }, [isCollapsed]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        QUICK_TASKS_SHOW_COMPLETED_KEY,
+        String(showCompletedTasks)
+      );
+    } catch {
+      // ignore storage write failures
+    }
+  }, [showCompletedTasks]);
 
   useEffect(() => {
     refreshTasks();
@@ -457,35 +497,73 @@ function QuickTasksSection() {
   return (
     <section className="quick-tasks-panel">
       <div className="quick-tasks-header">
-        <h2>Quick Tasks</h2>
-        <span className="quick-tasks-count">{sortedTasks.length}</span>
-      </div>
-
-      <div className="quick-task-add-row">
-        <input
-          type="text"
-          className="quick-task-input"
-          placeholder="Add a quick task..."
-          value={newTaskTitle}
-          onChange={(e) => setNewTaskTitle(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              e.preventDefault();
-              handleAddTask();
-            }
-          }}
-        />
-        <button className="quick-task-add-btn" onClick={handleAddTask}>
-          Add
+        <button
+          type="button"
+          className="quick-tasks-collapse-toggle"
+          onClick={() => setIsCollapsed((prev) => !prev)}
+          aria-expanded={!isCollapsed}
+          title={isCollapsed ? "Expand quick tasks" : "Collapse quick tasks"}
+        >
+          {isCollapsed ? "▶" : "▼"} Quick Tasks
         </button>
+        <div className="quick-tasks-counts">
+          <span className="quick-tasks-count open">Open {openTaskCount}</span>
+          <span className="quick-tasks-count done">Done {completedTaskCount}</span>
+          <span className="quick-tasks-count total">Total {tasks.length}</span>
+        </div>
       </div>
 
-      <div className="quick-task-list">
-        {sortedTasks.length === 0 && (
-          <p className="quick-tasks-empty">No quick tasks yet.</p>
+      <div className="quick-tasks-controls">
+        <button
+          type="button"
+          className={`quick-task-visibility-toggle ${showCompletedTasks ? "active" : ""}`}
+          onClick={() => setShowCompletedTasks((prev) => !prev)}
+          title={
+            showCompletedTasks
+              ? "Hide completed tasks from list"
+              : "Show completed tasks in list"
+          }
+        >
+          {showCompletedTasks ? "Hide completed" : "Show completed"}
+        </button>
+        {!showCompletedTasks && completedTaskCount > 0 && (
+          <span className="quick-tasks-hidden-hint">
+            {completedTaskCount} completed hidden
+          </span>
         )}
+      </div>
 
-        {sortedTasks.map((task) => {
+      {!isCollapsed && (
+        <>
+          <div className="quick-task-add-row">
+            <input
+              type="text"
+              className="quick-task-input"
+              placeholder="Add a quick task..."
+              value={newTaskTitle}
+              onChange={(e) => setNewTaskTitle(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  handleAddTask();
+                }
+              }}
+            />
+            <button className="quick-task-add-btn" onClick={handleAddTask}>
+              Add
+            </button>
+          </div>
+
+          <div className="quick-task-list">
+            {visibleTasks.length === 0 && (
+              <p className="quick-tasks-empty">
+                {tasks.length === 0
+                  ? "No quick tasks yet."
+                  : "No visible quick tasks. Toggle \"Show completed\" to view completed items."}
+              </p>
+            )}
+
+            {visibleTasks.map((task) => {
           const comments = task.comments || [];
           const checklist = [...(task.checklist || [])].sort(
             (a, b) => a.order - b.order
@@ -809,8 +887,10 @@ function QuickTasksSection() {
               )}
             </article>
           );
-        })}
-      </div>
+            })}
+          </div>
+        </>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
Closes #90

## Summary
- add collapsible behavior to the Quick Tasks panel with an explicit header toggle
- add persistent Open/Done/Total counts in the header for fast status scanning
- add `Show completed` toggle and auto-hide completed tasks when the toggle is off
- persist quick-task panel collapse and completed-visibility preferences in local storage
- include requested launch profile environment update to run API in Production mode locally

## Verification
- [x] `npm --prefix client run build`
- [x] No lint errors in modified frontend files
- [x] Existing quick-task details/comments/checklist interactions preserved

## Notes
- Build succeeds and still shows the existing local Node version warning (`22.11.0` vs Vite recommendation `22.12+`).

Made with [Cursor](https://cursor.com)