### PR TITLE
Quick Tasks: drag-and-drop ordering with persisted sequence

### DIFF
--- a/backend/src/Taskify.Api/Program.cs
+++ b/backend/src/Taskify.Api/Program.cs
@@ -598,6 +598,22 @@ app.MapDelete("api/quick-tasks/{id:int}", (int id, QuickTaskService svc) =>
         return Results.BadRequest(ex.Message);
     }
 });
+app.MapPut("api/quick-tasks/reorder", async (QuickTaskService svc, HttpRequest req) =>
+{
+    var body = await req.ReadFromJsonAsync<ReorderQuickTasksRequest>();
+    if (body == null || body.TaskOrders == null || body.TaskOrders.Count == 0)
+        return Results.BadRequest("taskOrders required");
+
+    try
+    {
+        svc.ReorderTasks(body.TaskOrders);
+        return Results.Ok();
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ex.Message);
+    }
+});
 app.MapGet("api/quick-tasks/{id:int}/comments", (int id, QuickTaskService svc) =>
 {
     try
@@ -896,4 +912,5 @@ public record UpdateQuickTaskCommentContentRequest(string Content);
 public record AddQuickTaskChecklistItemRequest(string Title, int? Order);
 public record ToggleQuickTaskChecklistItemRequest(bool IsCompleted);
 public record UpdateQuickTaskChecklistItemTitleRequest(string Title);
+public record ReorderQuickTasksRequest(Dictionary<int, int> TaskOrders);
 public record ReorderQuickTaskChecklistRequest(Dictionary<int, int> ChecklistOrders);

--- a/backend/src/Taskify.Infrastructure/Storage/QuickTaskService.cs
+++ b/backend/src/Taskify.Infrastructure/Storage/QuickTaskService.cs
@@ -103,6 +103,14 @@ public class QuickTaskService
         _store.ReorderChecklist(taskId, checklistOrders);
     }
 
+    public void ReorderTasks(Dictionary<int, int> taskOrders)
+    {
+        if (taskOrders == null || taskOrders.Count == 0)
+            throw new ArgumentException("Task order mapping cannot be empty", nameof(taskOrders));
+
+        _store.ReorderTasks(taskOrders);
+    }
+
     private static string ValidateTitle(string? title, string label)
     {
         if (string.IsNullOrWhiteSpace(title))

--- a/backend/src/Taskify.Infrastructure/Storage/QuickTaskStore.cs
+++ b/backend/src/Taskify.Infrastructure/Storage/QuickTaskStore.cs
@@ -27,6 +27,7 @@ public class QuickTaskStore
             return _model.Tasks
                 .Select(CloneTask)
                 .OrderBy(t => t.IsCompleted)
+                .ThenBy(t => t.Order)
                 .ThenByDescending(t => t.CreatedDate)
                 .ToList();
         }
@@ -42,6 +43,7 @@ public class QuickTaskStore
                 Id = _model.NextTaskId++,
                 Title = title,
                 IsCompleted = false,
+                Order = GetNextTaskOrder(false),
                 CreatedDate = now,
                 UpdatedDate = now
             };
@@ -74,6 +76,10 @@ public class QuickTaskStore
             if (task == null)
                 return false;
 
+            if (task.IsCompleted != isCompleted)
+            {
+                task.Order = GetNextTaskOrder(isCompleted, task.Id);
+            }
             task.IsCompleted = isCompleted;
             task.CompletedDate = isCompleted ? DateTime.UtcNow : null;
             task.UpdatedDate = DateTime.UtcNow;
@@ -337,6 +343,28 @@ public class QuickTaskStore
         }
     }
 
+    public bool ReorderTasks(Dictionary<int, int> taskToOrder)
+    {
+        lock (_syncRoot)
+        {
+            if (taskToOrder == null || taskToOrder.Count == 0)
+                return false;
+
+            foreach (var kvp in taskToOrder)
+            {
+                var task = _model.Tasks.FirstOrDefault(t => t.Id == kvp.Key);
+                if (task != null)
+                {
+                    task.Order = kvp.Value;
+                    task.UpdatedDate = DateTime.UtcNow;
+                }
+            }
+
+            Persist();
+            return true;
+        }
+    }
+
     private static QuickTaskItem CloneTask(QuickTaskModel model)
     {
         return new QuickTaskItem
@@ -344,6 +372,7 @@ public class QuickTaskStore
             Id = model.Id,
             Title = model.Title,
             IsCompleted = model.IsCompleted,
+            Order = model.Order,
             CreatedDate = model.CreatedDate,
             CompletedDate = model.CompletedDate,
             UpdatedDate = model.UpdatedDate,
@@ -409,6 +438,7 @@ public class QuickTaskStore
                                 checklistItem.UpdatedDate = checklistItem.CreatedDate;
                         }
                     }
+                    NormalizeTaskOrders(loaded);
                     return loaded;
                 }
             }
@@ -440,6 +470,29 @@ public class QuickTaskStore
         }
     }
 
+    private int GetNextTaskOrder(bool isCompleted, int? excludeTaskId = null)
+    {
+        var scoped = _model.Tasks
+            .Where(t => t.IsCompleted == isCompleted && t.Id != excludeTaskId);
+        return scoped.Any() ? scoped.Max(t => t.Order) + 1 : 0;
+    }
+
+    private static void NormalizeTaskOrders(QuickTaskStoreModel model)
+    {
+        var ordered = model.Tasks
+            .OrderBy(t => t.IsCompleted)
+            .ThenBy(t => t.Order)
+            .ThenByDescending(t => t.CreatedDate)
+            .ToList();
+
+        var openOrder = 0;
+        var doneOrder = 0;
+        foreach (var task in ordered)
+        {
+            task.Order = task.IsCompleted ? doneOrder++ : openOrder++;
+        }
+    }
+
     private class QuickTaskStoreModel
     {
         public int NextTaskId { get; set; }
@@ -453,6 +506,7 @@ public class QuickTaskStore
         public int Id { get; set; }
         public string Title { get; set; } = string.Empty;
         public bool IsCompleted { get; set; }
+        public int Order { get; set; }
         public DateTime CreatedDate { get; set; }
         public DateTime? CompletedDate { get; set; }
         public DateTime UpdatedDate { get; set; }
@@ -485,6 +539,7 @@ public class QuickTaskItem
     public int Id { get; set; }
     public string Title { get; set; } = string.Empty;
     public bool IsCompleted { get; set; }
+    public int Order { get; set; }
     public DateTime CreatedDate { get; set; }
     public DateTime? CompletedDate { get; set; }
     public DateTime UpdatedDate { get; set; }

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -388,6 +388,18 @@
   border-radius: 10px;
   padding: 0.55rem;
   background: rgba(255, 255, 255, 0.02);
+  cursor: grab;
+  transition: border-color 0.18s ease, background 0.18s ease, opacity 0.18s ease;
+}
+
+.quick-task-card.dragging {
+  opacity: 0.55;
+  cursor: grabbing;
+}
+
+.quick-task-card.drag-over {
+  border-color: rgba(56, 189, 248, 0.65);
+  background: rgba(56, 189, 248, 0.08);
 }
 
 .quick-task-row {
@@ -402,6 +414,13 @@
   align-items: center;
   gap: 0.45rem;
   min-width: 0;
+}
+
+.quick-task-drag-handle {
+  color: rgba(255, 255, 255, 0.45);
+  font-size: 0.8rem;
+  line-height: 1;
+  user-select: none;
 }
 
 .quick-task-title {

--- a/client/src/components/QuickTasksSection.jsx
+++ b/client/src/components/QuickTasksSection.jsx
@@ -31,6 +31,8 @@ function QuickTasksSection() {
   const [checklistDrafts, setChecklistDrafts] = useState({});
   const [editingCommentContent, setEditingCommentContent] = useState({});
   const [commentDrafts, setCommentDrafts] = useState({});
+  const [draggedTaskId, setDraggedTaskId] = useState(null);
+  const [dragOverTaskId, setDragOverTaskId] = useState(null);
   const [draggedChecklistItem, setDraggedChecklistItem] = useState(null);
   const formatLocalTimestamp = (value) => {
     if (!value) return "";
@@ -55,6 +57,11 @@ function QuickTasksSection() {
       [...tasks].sort((a, b) => {
         if (a.isCompleted !== b.isCompleted) {
           return Number(a.isCompleted) - Number(b.isCompleted);
+        }
+        const orderA = Number.isFinite(a.order) ? a.order : 0;
+        const orderB = Number.isFinite(b.order) ? b.order : 0;
+        if (orderA !== orderB) {
+          return orderA - orderB;
         }
         return new Date(b.createdDate) - new Date(a.createdDate);
       }),
@@ -485,6 +492,107 @@ function QuickTasksSection() {
     }
   };
 
+  const persistTaskOrder = async (orderedTasks) => {
+    const taskOrders = {};
+    orderedTasks.forEach((task, index) => {
+      taskOrders[task.id] = index;
+    });
+
+    await fetch(`${QUICK_TASKS_API_URL}/reorder`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ taskOrders })
+    });
+  };
+
+  const moveTaskByOffset = async (taskId, offset) => {
+    const sourceTask = visibleTasks.find((task) => task.id === taskId);
+    if (!sourceTask) return;
+
+    const group = visibleTasks.filter(
+      (task) => task.isCompleted === sourceTask.isCompleted
+    );
+    const sourceIndex = group.findIndex((task) => task.id === taskId);
+    const targetIndex = sourceIndex + offset;
+    if (sourceIndex < 0 || targetIndex < 0 || targetIndex >= group.length) return;
+
+    const reorderedGroup = [...group];
+    const [movedTask] = reorderedGroup.splice(sourceIndex, 1);
+    reorderedGroup.splice(targetIndex, 0, movedTask);
+
+    const indexById = new Map(reorderedGroup.map((task, idx) => [task.id, idx]));
+    const nextTasks = tasks.map((task) =>
+      indexById.has(task.id)
+        ? {
+            ...task,
+            order: indexById.get(task.id),
+            updatedDate: new Date().toISOString()
+          }
+        : task
+    );
+
+    setTasks(nextTasks);
+    try {
+      await persistTaskOrder(reorderedGroup);
+    } catch (err) {
+      console.error("Failed to reorder quick tasks", err);
+      refreshTasks();
+    }
+  };
+
+  const handleTaskDrop = async (targetTaskId) => {
+    if (!draggedTaskId || draggedTaskId === targetTaskId) {
+      setDraggedTaskId(null);
+      setDragOverTaskId(null);
+      return;
+    }
+
+    const sourceTask = visibleTasks.find((task) => task.id === draggedTaskId);
+    const targetTask = visibleTasks.find((task) => task.id === targetTaskId);
+    if (!sourceTask || !targetTask || sourceTask.isCompleted !== targetTask.isCompleted) {
+      setDraggedTaskId(null);
+      setDragOverTaskId(null);
+      return;
+    }
+
+    const group = visibleTasks.filter(
+      (task) => task.isCompleted === sourceTask.isCompleted
+    );
+    const sourceIndex = group.findIndex((task) => task.id === draggedTaskId);
+    const targetIndex = group.findIndex((task) => task.id === targetTaskId);
+    if (sourceIndex < 0 || targetIndex < 0) {
+      setDraggedTaskId(null);
+      setDragOverTaskId(null);
+      return;
+    }
+
+    const reorderedGroup = [...group];
+    const [movedTask] = reorderedGroup.splice(sourceIndex, 1);
+    reorderedGroup.splice(targetIndex, 0, movedTask);
+
+    const indexById = new Map(reorderedGroup.map((task, idx) => [task.id, idx]));
+    const nextTasks = tasks.map((task) =>
+      indexById.has(task.id)
+        ? {
+            ...task,
+            order: indexById.get(task.id),
+            updatedDate: new Date().toISOString()
+          }
+        : task
+    );
+
+    setTasks(nextTasks);
+    setDraggedTaskId(null);
+    setDragOverTaskId(null);
+
+    try {
+      await persistTaskOrder(reorderedGroup);
+    } catch (err) {
+      console.error("Failed to reorder quick tasks", err);
+      refreshTasks();
+    }
+  };
+
   if (loading) {
     return (
       <section className="quick-tasks-panel">
@@ -570,10 +678,40 @@ function QuickTasksSection() {
           );
           const completedChecklist = checklist.filter((i) => i.isCompleted).length;
 
-          return (
-            <article key={task.id} className="quick-task-card">
+              return (
+                <article
+                  key={task.id}
+                  className={`quick-task-card ${draggedTaskId === task.id ? "dragging" : ""} ${dragOverTaskId === task.id ? "drag-over" : ""}`}
+                  draggable
+                  onDragStart={(e) => {
+                    setDraggedTaskId(task.id);
+                    e.dataTransfer.effectAllowed = "move";
+                    e.dataTransfer.setData("text/plain", String(task.id));
+                  }}
+                  onDragOver={(e) => {
+                    e.preventDefault();
+                    e.dataTransfer.dropEffect = "move";
+                    setDragOverTaskId(task.id);
+                  }}
+                  onDragLeave={() => {
+                    if (dragOverTaskId === task.id) {
+                      setDragOverTaskId(null);
+                    }
+                  }}
+                  onDrop={(e) => {
+                    e.preventDefault();
+                    handleTaskDrop(task.id);
+                  }}
+                  onDragEnd={() => {
+                    setDraggedTaskId(null);
+                    setDragOverTaskId(null);
+                  }}
+                >
               <div className="quick-task-row">
                 <label className="quick-task-title-row">
+                      <span className="quick-task-drag-handle" title="Drag to reorder">
+                        ⋮⋮
+                      </span>
                   <input
                     type="checkbox"
                     checked={task.isCompleted}
@@ -619,6 +757,22 @@ function QuickTasksSection() {
                 </label>
 
                 <div className="quick-task-meta">
+                      <button
+                        className="quick-task-inline-icon-btn"
+                        onClick={() => moveTaskByOffset(task.id, -1)}
+                        title="Move task up"
+                        aria-label={`Move ${task.title} up`}
+                      >
+                        ↑
+                      </button>
+                      <button
+                        className="quick-task-inline-icon-btn"
+                        onClick={() => moveTaskByOffset(task.id, 1)}
+                        title="Move task down"
+                        aria-label={`Move ${task.title} down`}
+                      >
+                        ↓
+                      </button>
                   {editingTaskTitles[task.id] ? (
                     <>
                       <button


### PR DESCRIPTION
Closes #92

## Summary
- add a new backend endpoint to persist quick-task order (`PUT /api/quick-tasks/reorder`)
- extend quick-task storage/service models to track and maintain per-status task order
- add drag-and-drop reordering for quick-task cards in the UI
- add keyboard-accessible `Move up`/`Move down` controls for quick-task ordering
- keep existing quick-task behaviors intact (collapse/filter/details/comments/checklist)

## Validation
- [x] `npm --prefix client run build`
- [x] `dotnet test backend/Taskify.sln --configuration Release`
- [x] No lint errors in changed files

## Notes
- Existing environment warnings remain unchanged (Node/Vite and pre-existing analyzer warnings).

Made with [Cursor](https://cursor.com)