### PR TITLE
feat: extract assignment data and define domain shape

### DIFF
--- a/src/features/assignment/components/AssignmentCard.jsx
+++ b/src/features/assignment/components/AssignmentCard.jsx
@@ -1,10 +1,15 @@
+import { PRIORITY_LABELS } from '../data/assignmentsData';
+
 function AssignmentCard({assignment}) {
    return (
     <div>
-      <h3>{assignment.title}</h3>
+      <h3>{assignment.name}</h3>
       <p>{assignment.description}</p>
-      <p>{assignment.dueDate}</p>
+      <p>{assignment.client}</p>
+      <p>{PRIORITY_LABELS[assignment.priority]}</p>
       <p>{assignment.status}</p>
+      <p>{assignment.assignee}</p>
+      <p>{assignment.deadline}</p>
     </div>
   );
 }

--- a/src/features/assignment/components/AssignmentList.jsx
+++ b/src/features/assignment/components/AssignmentList.jsx
@@ -1,35 +1,11 @@
 import AssignmentCard from './AssignmentCard';
-
- const assignmentList = [
-    {
-      id: 1,
-      title: "Assignment 1",
-      description: "Description 1",
-      dueDate: "2026-01-01",
-      status: "In Progress"
-    },
-    {
-      id: 2,
-      title: "Assignment 2",
-      description: "Description 2",
-      dueDate: "2026-01-02",
-      status: "Pending"
-    },
-
-    {
-      id: 3,
-      title: "Assignment 3",
-      description: "Description 3",
-      dueDate: "2026-01-03",
-      status: "Done"
-    }
-  ];
+import { assignments } from '../data/assignmentsData';
 
   function AssignmentList() {
     return (
         <div>
             <h2>Assignments</h2>
-            {assignmentList.map((assignment) => (
+            {assignments.map((assignment) => (
                 <AssignmentCard key={assignment.id} assignment={assignment}/>
             ))}
         </div>

--- a/src/features/assignment/data/assignmentsData.js
+++ b/src/features/assignment/data/assignmentsData.js
@@ -1,0 +1,62 @@
+/**
+ * @typedef {object} Assignment
+ * @property {number} id - M-Files Object ID
+ * @property {string} name - Assignment name
+ * @property {string} description - Assignment description
+ * @property {string} client - O'Neil client name
+ * @property {number} priority - 1=Critical, 2=High, 3=Medium, 4=Low, 5=Not Determined
+ * @property {string} status - M-Files workflow state. See ASSIGNMENT_STATES
+ * @property {string} assignee - Assigned team member
+ * @property {string} deadline - ISO 8601 date string
+ */
+
+export const PRIORITY_LABELS = {
+  1: "Critical",
+  2: "High",
+  3: "Medium",
+  4: "Low",
+  5: "Not Determined Yet"
+};
+
+export const ASSIGNMENTS_STATES = {
+  ASSIGNED: "Assigned",
+  // User reviews description, moves to In Progress when understood
+  // TODO: V2 - AI breakdown of assignment into actionables
+
+  IN_PROGRESS: "In Progress",
+  // User is actively working on the assignment
+
+  ON_HOLD: "On Hold",
+  // Blocked - waiting on client response or external dependency
+
+  UPDATE_REQUIRED: "Update Required",
+  // Manager/HOD needs an update from assignee
+  // TODO: v2 - UI alert to replace current email notification (email unreliable)
+
+  AWAITING_REVIEW: "Awaiting Review",
+  // User submits for review, Approval Assignment created and linked
+  // Both team lead and HOD must approve
+  // On rejection: returns to In Progress, user checks assignment + approval for comments
+
+  APPROVED: "Approved",
+  // Dual approval complete, user can mark as complete
+
+  COMPLETED: "Completed",
+  // Assignment marked complete by user
+
+  BILLED: "Billed"
+  // Completed and billed, archive state
+};
+
+export const assignments = [
+  {
+    id: 1,
+    name: "Assignment Name",
+    description: "Assignment Description",
+    client: "O'Neil Client",
+    priority: 3,
+    status: ASSIGNMENTS_STATES.IN_PROGRESS,
+    assignee: "John Doe",
+    deadline: "2025-06-01"
+  }
+];


### PR DESCRIPTION
**Linked Issue:** Closes #5 

## Summary

Extracts hardcoded assignment data out of `AssignmentList.jsx` into a dedicated data file, and defines the core domain shape for an Assignment object ahead of M-Files API integration.

## Changes

- **Added** `features/assignment/data/assignmentsData.jsx`
    - `Assignment` typedef documenting the domain shape
    - `PRIORITY_LABELS` map (numeric M-Files priority -> display string)
    - `ASSIGNMENT_STATES` constants covering the full assignment lifecycle
    - Hardcoded `assignments` array (placeholder until API integration)
- **Updated** `AssignmentList.jsx` - imports data from `assignmentsData.js`
- **Updated** `AssignmentCard.jsx` - resolves priority label via `PRIORITY_LABELS`

## Why

Separates data from presentation. Components should not own data.
This also establishes the domain vocabulary (`ASSIGNMENT_STATES`, `PRIORITY_LABELS`) that the rest of the app will build on, and makes the TypeScript migration straightforward when we get there.

## Notes

- No change in browser output
- `ASSIGNMENT_STATES` includes TODO comments for V2 features (AI breakdown on Assigned state, UI alerts for Update Required)
- Approval workflow complexity noted for future design session before implementation