### PR TITLE
feat: scaffold assignment sliding detail panel

### DIFF
--- a/src/features/assignment/components/AssignmentCard.jsx
+++ b/src/features/assignment/components/AssignmentCard.jsx
@@ -2,7 +2,7 @@ import { PRIORITY_LABELS, ASSIGNMENT_STATES } from "../data/data";
 import { getPriorityClass, getStatusClass } from "../utils/classHelpers";
 import { parseDDMMYYYY, formatDate } from "../utils/dateUtils";
 
-function AssignmentCard({ assignment }) {
+function AssignmentCard({ assignment, onCardClick }) {
   const assignmentDeadline = parseDDMMYYYY(assignment.deadline);
 
   const isOverdue =
@@ -18,7 +18,9 @@ function AssignmentCard({ assignment }) {
 
   return (
     <li
-      className={`assignment-card ${getPriorityClass(PRIORITY_LABELS[assignment.priority])}`}
+      className={`assignment-card 
+      ${getPriorityClass(PRIORITY_LABELS[assignment.priority])}`}
+      onClick={() => onCardClick(assignment)}
     >
       <h3 className="card-title">{assignment.title}</h3>
       <hr className="card-divider"/>

--- a/src/features/assignment/components/AssignmentGrid.jsx
+++ b/src/features/assignment/components/AssignmentGrid.jsx
@@ -1,14 +1,39 @@
 import AssignmentCard from "./AssignmentCard";
 import { ASSIGNMENTS } from "../data/data";
+import { useState } from 'react';
+import DetailPanel from './DetailPanel';
 
 function AssignmentGrid() {
+  const [selectedAssignment, setSelectedAssignment] = useState(null);
+  const [isPanelOpen, setIsPanelOpen] = useState(false);
+
+  const handleCardClick = (assignment) => {
+    setSelectedAssignment(assignment);
+    setIsPanelOpen(true);
+  }
+
+  const handleClosePanel = () => {
+    setIsPanelOpen(false);
+    setTimeout(() => setSelectedAssignment(null), 300);
+  }
+
   return (
     <div>
       <ul className="assignment-grid">
         {ASSIGNMENTS.map((assignment) => (
-          <AssignmentCard key={assignment.id} assignment={assignment} />
+          <AssignmentCard 
+            key={assignment.id} 
+            assignment={assignment} 
+            onCardClick={handleCardClick}
+          />
         ))}
       </ul>
+
+      <DetailPanel 
+        assignment={selectedAssignment}
+        isOpen={isPanelOpen}
+        onClose={handleClosePanel}
+      />
     </div>
   );
 }

--- a/src/features/assignment/components/DetailPanel.css
+++ b/src/features/assignment/components/DetailPanel.css
@@ -1,0 +1,174 @@
+/* Slide-out panel */
+.detail-panel {
+    position: fixed;
+    top: 0;
+    right: -100%;
+    width: min(480px, 100%);
+    height: 100%;
+    background: white;
+    box-shadow: -4px 0 20px rgba(0, 0, 0, 0.15);
+    transition: right 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    z-index: 1000;
+    overflow-y: auto;
+    padding: 2rem;
+}
+
+
+.detail-panel.open {
+    right: 0;
+}
+
+.panel-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.3);
+    z-index: 999;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+}
+
+.panel-overlay.open {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.panel-close {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    background: #f1f5f9;
+    border: none;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    font-size: 1.25rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #475569;
+    transition: all 0.2s;
+}
+
+.panel-close:hover {
+    background: #e2e8f0;
+    color: #0f172a;
+}
+
+.panel-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #0f172a;
+    margin-bottom: 1rem;
+    padding-right: 2rem;
+}
+
+.panel-section {
+    margin-bottom: 1.5rem;
+}
+
+.panel-section h4 {
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #94a3b8;
+    margin-bottom: 0.5rem;
+}
+
+.panel-section p,
+.panel-section .panel-text {
+    font-size: 0.95rem;
+    color: #1e293b;
+    line-height: 1.6;
+}
+
+.panel-divider {
+    border: none;
+    border-top: 1px solid #f1f5f9;
+    margin: 1.5rem 0;
+}
+
+.panel-comment {
+    background: #f8fafc;
+    padding: 0.75rem;
+    border-radius: 6px;
+    margin-bottom: 0.5rem;
+    font-size: 0.9rem;
+    border-left: 3px solid #94a3b8;
+}
+
+.panel-comment .comment-author {
+    font-weight: 600;
+    font-size: 0.8rem;
+    color: #0f172a;
+}
+
+.panel-comment .comment-date {
+    font-size: 0.7rem;
+    color: #94a3b8;
+    margin-left: 0.5rem;
+}
+
+.panel-comment .comment-text {
+    margin-top: 0.25rem;
+    color: #475569;
+}
+
+.panel-subtask {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.5rem 0;
+    border-bottom: 1px solid #f1f5f9;
+}
+
+.panel-subtask input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    accent-color: #2563eb;
+    cursor: pointer;
+}
+
+.panel-subtask .subtask-text {
+    font-size: 0.9rem;
+    color: #1e293b;
+}
+
+.panel-subtask .subtask-text.done {
+    text-decoration: line-through;
+    color: #94a3b8;
+}
+
+.panel-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.panel-action-btn {
+    padding: 0.5rem 1rem;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.panel-action-btn--primary {
+    background: #2563eb;
+    color: white;
+}
+
+.panel-action-btn--secondary {
+    background: #f1f5f9;
+    color: #0f172a;
+}
+
+.panel-section-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+}

--- a/src/features/assignment/components/DetailPanel.jsx
+++ b/src/features/assignment/components/DetailPanel.jsx
@@ -1,0 +1,108 @@
+import { PRIORITY_LABELS } from "../data/data";
+import { parseDDMMYYYY, formatDate } from "../utils/dateUtils";
+
+function DetailPanel({ assignment, isOpen, onClose }) {
+    if (!assignment) return null;
+
+    return (
+        <>
+        <div
+            className={`panel-overlay ${isOpen ? "open" : ""}`}
+            onClick={onClose}
+        />
+        <div className={`detail-panel ${isOpen ? "open" : ""}`}>
+            <button className="panel-close" onClick={onClose}>
+            ✕
+            </button>
+
+            <h3 className="panel-title">{assignment.title}</h3>
+
+            <div className="panel-section">
+            <h4>Description</h4>
+            <p>{assignment.description}</p>
+            </div>
+
+            <hr className="panel-divider" />
+
+            <div className={`panel-section panel-section-grid`}>
+            <div>
+                <h4>Status</h4>
+                <p className="panel-text">
+                <strong>{assignment.status}</strong>
+                </p>
+            </div>
+            <div>
+                <h4>Priority</h4>
+                <p className="panel-text">
+                <strong>{PRIORITY_LABELS[assignment.priority]}</strong>
+                </p>
+            </div>
+            <div>
+                <h4>Assignee</h4>
+                <p className="panel-text">{assignment.assignee}</p>
+            </div>
+            <div>
+                <h4>Deadline</h4>
+                <p className="panel-text">
+                {formatDate(parseDDMMYYYY(assignment.deadline))}
+                </p>
+            </div>
+            <div>
+                <h4>Client</h4>
+                <p className="panel-text">{assignment.client}</p>
+            </div>
+            </div>
+
+            <hr className="panel-divider" />
+
+            {assignment.subtasks && assignment.subtasks.length > 0 && (
+            <div className="panel-section">
+                <h4>Subtasks</h4>
+                {assignment.subtasks.map((task) => (
+                <div key={task.id} className="panel-subtask">
+                    <input type="checkbox" checked={task.done} readOnly />
+                    <span
+                    className={`subtask-text ${task.done ? "done" : ""}`}
+                    >
+                    {task.text}
+                    </span>
+                </div>
+                ))}
+            </div>
+            )}
+
+            {assignment.comments && assignment.comments.length > 0 && (
+            <div className="panel-section">
+                <h4>Comments</h4>
+                {assignment.comments.map((comment) => (
+                <div key={comment.id} className="panel-comment">
+                    <span className="comment-author">{comment.author}</span>
+                    <span className="comment-date">{comment.date}</span>
+                    <div className="comment-text">{comment.text}</div>
+                </div>
+                ))}
+            </div>
+            )}
+
+            <hr className="panel-divider" />
+
+            <div className="panel-section">
+            <h4>Actions</h4>
+            <div className="panel-actions">
+                <button className="panel-action-btn panel-action-btn--primary">
+                Start Work
+                </button>
+                <button className="panel-action-btn panel-action-btn--secondary">
+                Add Comment
+                </button>
+                <button className="panel-action-btn panel-action-btn--secondary">
+                Add Subtask
+                </button>
+            </div>
+            </div>
+        </div>
+        </>
+    );
+}
+
+export default DetailPanel;

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,7 @@
 @import url('./app/App.css');
 @import url('./features//assignment/components/AssignmentGrid.css');
 @import url('./features/assignment/components/assignmentCard.css');
+@import url('./features//assignment/components/DetailPanel.css');
 
 #root {
     max-width: 1400px;


### PR DESCRIPTION
## Summary
Add a DetailPanel which slides in from the right to left and displays more details about the assignment. Shows a styled metadata of the assignment card and has placeholder actions button.

## Changes
- Added DetailPanel.jsx
- Added DetailPanel.css
- Updated the index.css to reference the DetailPane.css
- Updated AssignmentGrid.jsx to manage panel open/close state and pass selected assignment to DetailPanel

## Notes
- No change to data layer
- DetailPanel ready for reminders feature

## Linked Issue
Closes #12 