### PR TITLE
feat: focus tagging system

### DIFF
--- a/src/features/assignment/components/AssignmentGrid.jsx
+++ b/src/features/assignment/components/AssignmentGrid.jsx
@@ -1,26 +1,68 @@
 import AssignmentCard from "./AssignmentCard";
-import { ASSIGNMENTS } from "../data/data";
+import { ASSIGNMENTS, TABS } from "../data/data";
 import { useState } from 'react';
 import DetailPanel from './DetailPanel';
 
 function AssignmentGrid() {
+  const [activeTab, setActiveTab] = useState("today");
   const [selectedAssignment, setSelectedAssignment] = useState(null);
   const [isPanelOpen, setIsPanelOpen] = useState(false);
+
+  const getFilteredAssignments = () => {
+    if (activeTab === "today") {
+      return ASSIGNMENTS.filter((a) => a.today);
+    } else if (activeTab === "week") {
+      return ASSIGNMENTS.filter((a) => a.thisWeek);
+    } else {
+      return ASSIGNMENTS;
+    }
+  };
 
   const handleCardClick = (assignment) => {
     setSelectedAssignment(assignment);
     setIsPanelOpen(true);
-  }
+  };
 
   const handleClosePanel = () => {
     setIsPanelOpen(false);
     setTimeout(() => setSelectedAssignment(null), 300);
-  }
+  };
+
+  const filtered = getFilteredAssignments();
 
   return (
     <div>
+      <div className="tabs">
+        <button
+          className={`tab-btn ${activeTab === TABS.TODAY ? "active" : ""}`}
+          onClick={() => setActiveTab(TABS.TODAY)}
+        >
+          Today
+          <span className="tab-count">
+            {ASSIGNMENTS.filter((a) => a.today).length}
+          </span>
+        </button>
+        <button
+          className={`tab-btn ${activeTab === TABS.THIS_WEEK ? "active" : ""}`}
+          onClick={() => setActiveTab(TABS.THIS_WEEK)}
+        >
+          This Week
+          <span className="tab-count">
+            {ASSIGNMENTS.filter((a) => a.thisWeek).length}
+          </span>
+        </button>
+        <button
+          className={`tab-btn ${activeTab === TABS.ALL ? "active" : ""}`}
+          onClick={() => setActiveTab(TABS.ALL)}
+        >
+          All Assignments
+          <span className="tab-count">{ASSIGNMENTS.length}</span>
+        </button>
+
+      </div>
+
       <ul className="assignment-grid">
-        {ASSIGNMENTS.map((assignment) => (
+        {filtered.map((assignment) => (
           <AssignmentCard 
             key={assignment.id} 
             assignment={assignment} 
@@ -28,6 +70,10 @@ function AssignmentGrid() {
           />
         ))}
       </ul>
+
+      {filtered.length === 0 && (
+        <p className="tab-empty-state">No assignments for this period</p>
+      )}
 
       <DetailPanel 
         assignment={selectedAssignment}

--- a/src/features/assignment/components/AssignmentTab.css
+++ b/src/features/assignment/components/AssignmentTab.css
@@ -1,0 +1,66 @@
+/* Tabs */
+.tabs {
+    display: flex;
+    gap: 0.25rem;
+    overflow-x: auto;
+    margin-bottom: 1.5rem;
+    border-bottom: 2px solid #e2e8f0;
+    padding-bottom: 0.6rem;
+}
+
+.tab-empty-state {
+    text-align: center;
+    color: #94a3b8;
+    padding: 3rem 0;
+}
+
+.tab-btn {
+    padding: 0.6rem 1.5rem;
+    border: none;
+    background: transparent;
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: #64748b;
+    cursor: pointer;
+    border-radius: 6px;
+    transition: all 0.2s;
+    position: relative;
+}
+
+.tab-btn:hover {
+    background: #f1f5f9;
+    color: #0f172a;
+}
+
+.tab-btn.active {
+    color: #2563eb;
+    background: #eff6ff;
+}
+
+.tab-btn.active::after {
+    content: '';
+    position: absolute;
+    bottom: -0.55rem;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 60%;
+    height: 3px;
+    background: #2563eb;
+    border-radius: 2px;
+}
+
+.tab-count {
+    display: inline-block;
+    background: #e2e8f0;
+    color: #475569;
+    font-size: 0.7rem;
+    padding: 0.1rem 0.5rem;
+    border-radius: 12px;
+    margin-left: 0.4rem;
+    font-weight: 600;
+}
+
+.tab-btn.active .tab-count {
+    background: #2563eb;
+    color: white;
+}

--- a/src/features/assignment/data/data.js
+++ b/src/features/assignment/data/data.js
@@ -27,6 +27,8 @@
  * @property {string} status - M-Files workflow state. See ASSIGNMENT_STATES
  * @property {string} assignee - Assigned team member
  * @property {string} deadline - ISO 8601 date string
+ * @property {boolean} today - Assignment flag for tabs classification
+ * @property {boolean} thisWeek - Assignment flag for tabs classification
  * @property {Array<Comment>} comments - Version-specific comments on the assignment
  * @property {Array<Subtask>} subtasks - Actionable sub-items for this assignment
  * @property {Array<Note>} notes - Internal notes on the assignment
@@ -39,6 +41,12 @@ export const PRIORITY_LABELS = {
   3: "Medium",
   4: "Low",
   5: "Not Determined Yet"
+};
+
+export const TABS = {
+  TODAY: "today",
+  THIS_WEEK: "week",
+  ALL: "all"
 };
 
 export const ASSIGNMENT_STATES = {
@@ -82,6 +90,8 @@ export const ASSIGNMENTS = [
     status: ASSIGNMENT_STATES.ASSIGNED,
     assignee: "Fiina Amupolo",
     deadline: "09/07/2026",
+    today: true,
+    thisWeek: true,
     comments: [
       {
         id: 1,
@@ -132,6 +142,8 @@ export const ASSIGNMENTS = [
     status: ASSIGNMENT_STATES.IN_PROGRESS,
     assignee: "Casey Damens",
     deadline: "24/04/2026",
+    today: true,
+    thisWeek: true,
     comments: [
       {
         id: 1,
@@ -179,6 +191,8 @@ export const ASSIGNMENTS = [
     status: ASSIGNMENT_STATES.ON_HOLD,
     assignee: "Johanna Hosea",
     deadline: "21/07/2026",
+    today: false,
+    thisWeek: true,
     comments: [],
     subtasks: [
       {
@@ -204,6 +218,8 @@ export const ASSIGNMENTS = [
     status: ASSIGNMENT_STATES.UPDATE_REQUIRED,
     assignee: "Malakia Jeremia",
     deadline: "24/06/2026",
+    today: false,
+    thisWeek: false,
     comments: [
       {
         id: 1,
@@ -226,6 +242,8 @@ export const ASSIGNMENTS = [
     status: ASSIGNMENT_STATES.AWAITING_REVIEW,
     assignee: "Michael Sekhubede",
     deadline: "30/09/2026",
+    today: false,
+    thisWeek: false,
     comments: [],
     subtasks: [],
     notes: [],
@@ -241,6 +259,8 @@ export const ASSIGNMENTS = [
     status: ASSIGNMENT_STATES.APPROVED,
     assignee: "Denilson Uariua",
     deadline: "18/12/2026",
+    today: false,
+    thisWeek: false,
     comments: [],
     subtasks: [],
     notes: [],
@@ -256,6 +276,8 @@ export const ASSIGNMENTS = [
     status: ASSIGNMENT_STATES.COMPLETED,
     assignee: "David Van Rooyen",
     deadline: "22/06/2026",
+    today: false,
+    thisWeek: false,
     comments: [],
     subtasks: [],
     notes: [],
@@ -272,6 +294,8 @@ export const ASSIGNMENTS = [
     status: ASSIGNMENT_STATES.BILLED,
     assignee: "Casey Damens",
     deadline: "27/05/2026",
+    today: false,
+    thisWeek: false,
     comments: [],
     subtasks: [],
     notes: [],

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,8 @@
 @import url('./app/App.css');
-@import url('./features//assignment/components/AssignmentGrid.css');
+@import url('./features/assignment/components/AssignmentGrid.css');
 @import url('./features/assignment/components/assignmentCard.css');
-@import url('./features//assignment/components/DetailPanel.css');
+@import url('./features/assignment/components/DetailPanel.css');
+@import url('./features/assignment/components/AssignmentTab.css');
 
 #root {
     max-width: 1400px;


### PR DESCRIPTION
## Summary
Added tabs (Today, This Week, All Assignments) with assignment count to the AssignmentGrid. Updated the data.js with today, thisWeek tags on each assignment. Added styling (AssignmentTab.css) for the tabs.

## Changes
- Updated the data.js and added today and thisWeek fields to the assignments
- Added AssignmentTab.css for tab styling

## Notes
- today and thisWeek are boolean flags on each assignment
- Tags are hardcoded in data.js - localStorage persistence is a future milestone
- Today tab enforces a deliberate 3-assignment WIP limit (by data convention for now)
- TABS constant added to data.js to avoid magic strings in tab comparisons

## Linked Issue
Closes #13 